### PR TITLE
Add tuple_size and tuple_element support to the UMP types.

### DIFF
--- a/include/midi2/ump_to_bytestream.hpp
+++ b/include/midi2/ump_to_bytestream.hpp
@@ -96,68 +96,44 @@ private:
   struct to_bytestream_config {
     struct system {
       static void midi_time_code(context_type *const ctxt, types::system::midi_time_code const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::midi_time_code::w)> == 1);
         static_assert(bytestream_message_size<status::timing_code>() == 2);
-        using word0 = types::system::midi_time_code::word0;
-        auto const &w0 = get<word0>(in.w);
-        system::push(ctxt, w0.get<word0::group>(), status::timing_code, std::byte{w0.get<word0::time_code>()});
+        system::push(ctxt, in.group(), status::timing_code, std::byte{in.time_code()});
       }
       static void song_position_pointer(context_type *const ctxt, types::system::song_position_pointer const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::song_position_pointer::w)> == 1);
         static_assert(bytestream_message_size<status::spp>() == 3);
-        using word0 = types::system::song_position_pointer::word0;
-        auto const &w0 = get<word0>(in.w);
-        system::push(ctxt, w0.get<word0::group>(), status::spp, std::byte{w0.get<word0::position_lsb>()},
-                     std::byte{w0.get<word0::position_msb>()});
+        system::push(ctxt, in.group(), status::spp, std::byte{in.position_lsb()}, std::byte{in.position_msb()});
       }
       static void song_select(context_type *const ctxt, types::system::song_select const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::song_select::w)> == 1);
         static_assert(bytestream_message_size<status::song_select>() == 2);
-        using word0 = types::system::song_select::word0;
-        auto const &w0 = get<word0>(in.w);
-        system::push(ctxt, w0.get<word0::group>(), status::song_select, std::byte{w0.get<word0::song>()});
+        system::push(ctxt, in.group(), status::song_select, std::byte{in.song()});
       }
       static void tune_request(context_type *const ctxt, types::system::tune_request const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::tune_request::w)> == 1);
         static_assert(bytestream_message_size<status::tune_request>() == 1);
-        using word0 = types::system::tune_request::word0;
-        system::push(ctxt, std::get<word0>(in.w).get<word0::group>(), status::tune_request);
+        system::push(ctxt, in.group(), status::tune_request);
       }
       static void timing_clock(context_type *const ctxt, types::system::timing_clock const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::timing_clock::w)> == 1);
         static_assert(bytestream_message_size<status::timing_clock>() == 1);
-        using word0 = types::system::timing_clock::word0;
-        system::push(ctxt, std::get<word0>(in.w).get<word0::group>(), status::timing_clock);
+        system::push(ctxt, in.group(), status::timing_clock);
       }
       static void seq_start(context_type *const ctxt, types::system::sequence_start const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::sequence_start::w)> == 1);
         static_assert(bytestream_message_size<status::sequence_start>() == 1);
-        using word0 = types::system::sequence_start::word0;
-        system::push(ctxt, std::get<word0>(in.w).get<word0::group>(), status::sequence_start);
+        system::push(ctxt, in.group(), status::sequence_start);
       }
       static void seq_continue(context_type *const ctxt, types::system::sequence_continue const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::sequence_continue::w)> == 1);
         static_assert(bytestream_message_size<status::sequence_continue>() == 1);
-        using word0 = types::system::sequence_continue::word0;
-        system::push(ctxt, std::get<word0>(in.w).get<word0::group>(), status::sequence_continue);
+        system::push(ctxt, in.group(), status::sequence_continue);
       }
       static void seq_stop(context_type *const ctxt, types::system::sequence_stop const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::sequence_stop::w)> == 1);
         static_assert(bytestream_message_size<status::sequence_stop>() == 1);
-        using word0 = types::system::sequence_stop::word0;
-        system::push(ctxt, std::get<word0>(in.w).get<word0::group>(), status::sequence_stop);
+        system::push(ctxt, in.group(), status::sequence_stop);
       }
       static void active_sensing(context_type *const ctxt, types::system::active_sensing const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::active_sensing::w)> == 1);
         static_assert(bytestream_message_size<status::active_sensing>() == 1);
-        using word0 = types::system::active_sensing::word0;
-        system::push(ctxt, std::get<0>(in.w).get<word0::group>(), status::active_sensing);
+        system::push(ctxt, in.group(), status::active_sensing);
       }
       static void reset(context_type *const ctxt, types::system::reset const &in) {
-        static_assert(std::tuple_size_v<decltype(types::system::reset::w)> == 1);
         static_assert(bytestream_message_size<status::systemreset>() == 1);
-        using word0 = types::system::reset::word0;
-        system::push(ctxt, std::get<word0>(in.w).get<word0::group>(), status::systemreset);
+        system::push(ctxt, in.group(), status::systemreset);
       }
 
     private:
@@ -186,7 +162,6 @@ private:
         if (ctxt->filter_message(in)) {
           return;
         }
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::note_off::w)> == 1);
         static_assert(bytestream_message_size<status::note_off>() == 3);
         ctxt->push_back(std::byte{to_underlying(status::note_off)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.note()});
@@ -196,7 +171,6 @@ private:
         if (ctxt->filter_message(in)) {
           return;
         }
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::note_on::w)> == 1);
         static_assert(bytestream_message_size<status::note_on>() == 3);
         ctxt->push_back(std::byte{to_underlying(status::note_on)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.note()});
@@ -206,7 +180,6 @@ private:
         if (ctxt->filter_message(in)) {
           return;
         }
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::poly_pressure::w)> == 1);
         static_assert(bytestream_message_size<status::poly_pressure>() == 3);
         ctxt->push_back(std::byte{to_underlying(status::poly_pressure)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.note()});
@@ -216,7 +189,6 @@ private:
         if (ctxt->filter_message(in)) {
           return;
         }
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::control_change::w)> == 1);
         static_assert(bytestream_message_size<status::cc>() == 3);
         ctxt->push_back(std::byte{to_underlying(status::cc)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.controller()});
@@ -226,7 +198,6 @@ private:
         if (ctxt->filter_message(in)) {
           return;
         }
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::program_change::w)> == 1);
         static_assert(bytestream_message_size<status::program_change>() == 2);
         ctxt->push_back(std::byte{to_underlying(status::program_change)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.program()});
@@ -236,7 +207,6 @@ private:
           return;
         }
         static_assert(bytestream_message_size<status::channel_pressure>() == 2);
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::channel_pressure::w)> == 1);
         ctxt->push_back(std::byte{to_underlying(status::channel_pressure)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.data()});
       }
@@ -245,7 +215,6 @@ private:
           return;
         }
         static_assert(bytestream_message_size<status::pitch_bend>() == 3);
-        static_assert(std::tuple_size_v<decltype(types::m1cvm::pitch_bend::w)> == 1);
         ctxt->push_back(std::byte{to_underlying(status::pitch_bend)} | std::byte{in.channel()});
         ctxt->push_back(std::byte{in.lsb_data()});
         ctxt->push_back(std::byte{in.msb_data()});

--- a/include/midi2/ump_to_midi1.hpp
+++ b/include/midi2/ump_to_midi1.hpp
@@ -58,34 +58,34 @@ private:
     // system messages go straight through.
     struct system {
       static constexpr void midi_time_code(context_type *const ctxt, types::system::midi_time_code const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void song_position_pointer(context_type *const ctxt,
                                                   types::system::song_position_pointer const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void song_select(context_type *const ctxt, types::system::song_select const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void tune_request(context_type *const ctxt, types::system::tune_request const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void timing_clock(context_type *const ctxt, types::system::timing_clock const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void seq_start(context_type *const ctxt, types::system::sequence_start const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void seq_continue(context_type *const ctxt, types::system::sequence_continue const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void seq_stop(context_type *const ctxt, types::system::sequence_stop const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
       static constexpr void active_sensing(context_type *const ctxt, types::system::active_sensing const &in) {
-        ctxt->push(in.w);
+        ctxt->push(in);
       }
-      static constexpr void reset(context_type *const ctxt, types::system::reset const &in) { ctxt->push(in.w); }
+      static constexpr void reset(context_type *const ctxt, types::system::reset const &in) { ctxt->push(in); }
     };
     // m1cvm messages go straight through.
     struct m1cvm {

--- a/include/midi2/ump_to_midi2.hpp
+++ b/include/midi2/ump_to_midi2.hpp
@@ -42,15 +42,10 @@ public:
 
 private:
   struct context {
-    template <typename T, unsigned Index = 0>
+    template <typename T>
       requires(std::tuple_size_v<T> >= 0)
     constexpr void push(T const &value) {
-      if constexpr (Index >= std::tuple_size_v<T>) {
-        return;
-      } else {
-        output.push_back(get<Index>(value).word());
-        push<T, Index + 1>(value);
-      }
+      types::apply(value, [this](auto const v) { output.push_back(v.word()); });
     }
 
     struct bank {
@@ -119,24 +114,24 @@ private:
     // utility messages go straight through.
     struct utility {
       static constexpr void noop(context const *const) { /* Just consume NOOP messages */ }
-      static constexpr void jr_clock(context *const ctxt, types::utility::jr_clock const &in) { ctxt->push(in.w); }
-      static constexpr void jr_timestamp(context *const ctxt, types::utility::jr_timestamp const &in) { ctxt->push(in.w); }
-      static constexpr void delta_clockstamp_tpqn(context *const ctxt, types::utility::delta_clockstamp_tpqn const &in) { ctxt->push(in.w); }
-      static constexpr void delta_clockstamp(context *const ctxt, types::utility::delta_clockstamp const &in) { ctxt->push(in.w); }
+      static constexpr void jr_clock(context *const ctxt, types::utility::jr_clock const &in) { ctxt->push(in); }
+      static constexpr void jr_timestamp(context *const ctxt, types::utility::jr_timestamp const &in) { ctxt->push(in); }
+      static constexpr void delta_clockstamp_tpqn(context *const ctxt, types::utility::delta_clockstamp_tpqn const &in) { ctxt->push(in); }
+      static constexpr void delta_clockstamp(context *const ctxt, types::utility::delta_clockstamp const &in) { ctxt->push(in); }
       static constexpr void unknown(context const *, std::span<std::uint32_t>) { /* Just drop bad messages */ }
     };
     // system messages go straight through.
     struct system {
-      static constexpr void midi_time_code(context *const ctxt, types::system::midi_time_code const &in) { ctxt->push(in.w); }
-      static constexpr void song_position_pointer(context *const ctxt, types::system::song_position_pointer const &in) { ctxt->push(in.w); }
-      static constexpr void song_select(context *const ctxt, types::system::song_select const &in) { ctxt->push(in.w); }
-      static constexpr void tune_request(context *const ctxt, types::system::tune_request const &in) { ctxt->push(in.w); }
-      static constexpr void timing_clock(context *const ctxt, types::system::timing_clock const &in) { ctxt->push(in.w); }
-      static constexpr void seq_start(context *const ctxt, types::system::sequence_start const &in) { ctxt->push(in.w); }
-      static constexpr void seq_continue(context *const ctxt, types::system::sequence_continue const &in) { ctxt->push(in.w); }
-      static constexpr void seq_stop(context *const ctxt, types::system::sequence_stop const &in) { ctxt->push(in.w); }
-      static constexpr void active_sensing(context *const ctxt, types::system::active_sensing const &in) { ctxt->push(in.w); }
-      static constexpr void reset(context *const ctxt, types::system::reset const &in) { ctxt->push(in.w); }
+      static constexpr void midi_time_code(context *const ctxt, types::system::midi_time_code const &in) { ctxt->push(in); }
+      static constexpr void song_position_pointer(context *const ctxt, types::system::song_position_pointer const &in) { ctxt->push(in); }
+      static constexpr void song_select(context *const ctxt, types::system::song_select const &in) { ctxt->push(in); }
+      static constexpr void tune_request(context *const ctxt, types::system::tune_request const &in) { ctxt->push(in); }
+      static constexpr void timing_clock(context *const ctxt, types::system::timing_clock const &in) { ctxt->push(in); }
+      static constexpr void seq_start(context *const ctxt, types::system::sequence_start const &in) { ctxt->push(in); }
+      static constexpr void seq_continue(context *const ctxt, types::system::sequence_continue const &in) { ctxt->push(in); }
+      static constexpr void seq_stop(context *const ctxt, types::system::sequence_stop const &in) { ctxt->push(in); }
+      static constexpr void active_sensing(context *const ctxt, types::system::active_sensing const &in) { ctxt->push(in); }
+      static constexpr void reset(context *const ctxt, types::system::reset const &in) { ctxt->push(in); }
     };
     // m1cvm messages are converted to m2cvm messages.
     class m1cvm {
@@ -155,7 +150,7 @@ private:
                                      std::uint8_t const group, std::uint8_t const channel, std::uint8_t const value) {
         auto const out = T{}.group(group).channel(channel).bank(c.pn_msb).index(c.pn_lsb).value(
             mcm_scale<14, 32>(static_cast<std::uint16_t>((static_cast<std::uint16_t>(c.value_msb) << 7) | value)));
-        ctxt->push(out.w);
+        ctxt->push(out);
       }
     };
     // data64 messages go straight through.
@@ -215,34 +210,34 @@ private:
       }
     };
     struct data128 {
-      constexpr static void sysex8_in_1(context *const ctxt, types::data128::sysex8_in_1 const &in) { ctxt->push(in.w); }
-      constexpr static void sysex8_start(context *const ctxt, types::data128::sysex8_start const &in) { ctxt->push(in.w); }
-      constexpr static void sysex8_continue(context *const ctxt, types::data128::sysex8_continue const &in) { ctxt->push(in.w); }
-      constexpr static void sysex8_end(context *const ctxt, types::data128::sysex8_end const &in) { ctxt->push(in.w); }
-      constexpr static void mds_header(context *const ctxt, types::data128::mds_header const &in) { ctxt->push(in.w); }
-      constexpr static void mds_payload(context *const ctxt, types::data128::mds_payload const &in) { ctxt->push(in.w); }
+      constexpr static void sysex8_in_1(context *const ctxt, types::data128::sysex8_in_1 const &in) { ctxt->push(in); }
+      constexpr static void sysex8_start(context *const ctxt, types::data128::sysex8_start const &in) { ctxt->push(in); }
+      constexpr static void sysex8_continue(context *const ctxt, types::data128::sysex8_continue const &in) { ctxt->push(in); }
+      constexpr static void sysex8_end(context *const ctxt, types::data128::sysex8_end const &in) { ctxt->push(in); }
+      constexpr static void mds_header(context *const ctxt, types::data128::mds_header const &in) { ctxt->push(in); }
+      constexpr static void mds_payload(context *const ctxt, types::data128::mds_payload const &in) { ctxt->push(in); }
     };
     struct ump_stream {
-      constexpr static void endpoint_discovery(context *const ctxt, types::ump_stream::endpoint_discovery const &in) { ctxt->push(in.w); }
-      constexpr static void endpoint_info_notification(context *const ctxt, types::ump_stream::endpoint_info_notification const &in) { ctxt->push(in.w); }
-      constexpr static void device_identity_notification(context *const ctxt, types::ump_stream::device_identity_notification const &in) { ctxt->push(in.w); }
-      constexpr static void endpoint_name_notification(context *const ctxt, types::ump_stream::endpoint_name_notification const &in) { ctxt->push(in.w); }
-      constexpr static void product_instance_id_notification(context *const ctxt, types::ump_stream::product_instance_id_notification const &in) { ctxt->push(in.w); }
-      constexpr static void jr_configuration_request(context *const ctxt, types::ump_stream::jr_configuration_request const &in) { ctxt->push(in.w); }
-      constexpr static void jr_configuration_notification(context *const ctxt, types::ump_stream::jr_configuration_notification const &in) { ctxt->push(in.w); }
-      constexpr static void function_block_discovery(context *const ctxt, types::ump_stream::function_block_discovery const &in) { ctxt->push(in.w); }
-      constexpr static void function_block_info_notification(context *const ctxt, types::ump_stream::function_block_info_notification const &in) { ctxt->push(in.w); }
-      constexpr static void function_block_name_notification(context *const ctxt, types::ump_stream::function_block_name_notification const &in) { ctxt->push(in.w); }
-      constexpr static void start_of_clip(context *const ctxt, types::ump_stream::start_of_clip const &in) { ctxt->push(in.w); }
-      constexpr static void end_of_clip(context *const ctxt, types::ump_stream::end_of_clip const &in) { ctxt->push(in.w); }
+      constexpr static void endpoint_discovery(context *const ctxt, types::ump_stream::endpoint_discovery const &in) { ctxt->push(in); }
+      constexpr static void endpoint_info_notification(context *const ctxt, types::ump_stream::endpoint_info_notification const &in) { ctxt->push(in); }
+      constexpr static void device_identity_notification(context *const ctxt, types::ump_stream::device_identity_notification const &in) { ctxt->push(in); }
+      constexpr static void endpoint_name_notification(context *const ctxt, types::ump_stream::endpoint_name_notification const &in) { ctxt->push(in); }
+      constexpr static void product_instance_id_notification(context *const ctxt, types::ump_stream::product_instance_id_notification const &in) { ctxt->push(in); }
+      constexpr static void jr_configuration_request(context *const ctxt, types::ump_stream::jr_configuration_request const &in) { ctxt->push(in); }
+      constexpr static void jr_configuration_notification(context *const ctxt, types::ump_stream::jr_configuration_notification const &in) { ctxt->push(in); }
+      constexpr static void function_block_discovery(context *const ctxt, types::ump_stream::function_block_discovery const &in) { ctxt->push(in); }
+      constexpr static void function_block_info_notification(context *const ctxt, types::ump_stream::function_block_info_notification const &in) { ctxt->push(in); }
+      constexpr static void function_block_name_notification(context *const ctxt, types::ump_stream::function_block_name_notification const &in) { ctxt->push(in); }
+      constexpr static void start_of_clip(context *const ctxt, types::ump_stream::start_of_clip const &in) { ctxt->push(in); }
+      constexpr static void end_of_clip(context *const ctxt, types::ump_stream::end_of_clip const &in) { ctxt->push(in); }
     };
     struct flex_data {
-      constexpr static void set_tempo(context *const ctxt, types::flex_data::set_tempo const &in) { ctxt->push(in.w); }
-      constexpr static void set_time_signature(context *const ctxt, types::flex_data::set_time_signature const &in) { ctxt->push(in.w); }
-      constexpr static void set_metronome(context *const ctxt, types::flex_data::set_metronome const &in) { ctxt->push(in.w); }
-      constexpr static void set_key_signature(context *const ctxt, types::flex_data::set_key_signature const &in) { ctxt->push(in.w); }
-      constexpr static void set_chord_name(context *const ctxt, types::flex_data::set_chord_name const &in) { ctxt->push(in.w); }
-      constexpr static void text(context *const ctxt, types::flex_data::text_common const &in) { ctxt->push(in.w); }
+      constexpr static void set_tempo(context *const ctxt, types::flex_data::set_tempo const &in) { ctxt->push(in); }
+      constexpr static void set_time_signature(context *const ctxt, types::flex_data::set_time_signature const &in) { ctxt->push(in); }
+      constexpr static void set_metronome(context *const ctxt, types::flex_data::set_metronome const &in) { ctxt->push(in); }
+      constexpr static void set_key_signature(context *const ctxt, types::flex_data::set_key_signature const &in) { ctxt->push(in); }
+      constexpr static void set_chord_name(context *const ctxt, types::flex_data::set_chord_name const &in) { ctxt->push(in); }
+      constexpr static void text(context *const ctxt, types::flex_data::text_common const &in) { ctxt->push(in); }
     };
     struct context *context = nullptr;
     [[no_unique_address]] struct utility utility{};

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -135,6 +135,17 @@ private:
   UMP_GETTER(word, field)              \
   UMP_SETTER(word, field)
 
+#define UMP_TUPLE(group, message)                                                                                    \
+  template <>                                                                                                        \
+  struct std::tuple_size<midi2::types::group::message> /* NOLINT(cert-dcl58-cpp]*/                                   \
+      : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::group::message::words_)>> {};   \
+                                                                                                                     \
+  template <std::size_t I> struct std::tuple_element<I, midi2::types::group::message> { /* NOLINT(cert-dcl58-cpp] */ \
+    using type = std::tuple_element_t<I, decltype(midi2::types::group::message::words_)>;                            \
+  };                                                                                                                 \
+  static_assert(std::tuple_size_v<midi2::types::group::message> ==                                                   \
+                midi2::message_size<midi2::ump_message_type::group>::value);
+
 namespace midi2 {
 template <ump_message_type> struct message_size;  // not defined
 }  // end namespace midi2
@@ -161,7 +172,6 @@ class jr_clock;
 class jr_timestamp;
 class delta_clockstamp_tpqn;
 class delta_clockstamp;
-class song_position_pointer;
 
 }  // end namespace midi2::types::utility
 
@@ -194,18 +204,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a noop message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::utility::noop>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::utility::noop::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the noop message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::noop> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::utility::noop::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::utility::noop> ==
-              midi2::message_size<midi2::ump_message_type::utility>::value);
+UMP_TUPLE(utility, noop)  // Define tuple_size and tuple_element for noop
 
 // 7.2.2.1 JR Clock Message
 class midi2::types::utility::jr_clock {
@@ -240,18 +239,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a jr_clock message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::utility::jr_clock>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::utility::jr_clock::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the jr_clock message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::jr_clock> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::utility::jr_clock::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::utility::jr_clock> ==
-              midi2::message_size<midi2::ump_message_type::utility>::value);
+UMP_TUPLE(utility, jr_clock)  // Define tuple_size and tuple_element for jr_clock
 
 // 7.2.2.2 JR Timestamp Message
 class midi2::types::utility::jr_timestamp {
@@ -286,18 +274,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a jr_timestamp message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::utility::jr_timestamp>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::utility::jr_timestamp::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the jr_timestamp message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::jr_timestamp> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::utility::jr_timestamp::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::utility::jr_timestamp> ==
-              midi2::message_size<midi2::ump_message_type::utility>::value);
+UMP_TUPLE(utility, jr_timestamp)  // Define tuple_size and tuple_element for jr_timestamp
 
 // 7.2.3.1 Delta Clockstamp Ticks Per Quarter Note (DCTPQ)
 class midi2::types::utility::delta_clockstamp_tpqn {
@@ -332,20 +309,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a delta_clockstamp_tpqn message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::utility::delta_clockstamp_tpqn>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::utility::delta_clockstamp_tpqn::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the delta_clockstamp_tpqn message.
-template <std::size_t I>
-struct std::tuple_element<I, midi2::types::utility::delta_clockstamp_tpqn> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::utility::delta_clockstamp_tpqn::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::utility::delta_clockstamp_tpqn> ==
-              midi2::message_size<midi2::ump_message_type::utility>::value);
+UMP_TUPLE(utility, delta_clockstamp_tpqn)  // Define tuple_size and tuple_element for delta_clockstamp_tpqn
 
 // 7.2.3.2 Delta Clockstamp (DC): Ticks Since Last Event
 class midi2::types::utility::delta_clockstamp {
@@ -379,20 +343,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a delta_clockstamp message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::utility::delta_clockstamp>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::utility::delta_clockstamp::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the delta_clockstamp message.
-template <std::size_t I>
-struct std::tuple_element<I, midi2::types::utility::delta_clockstamp> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element_t<I, decltype(midi2::types::utility::delta_clockstamp::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::utility::delta_clockstamp> ==
-              midi2::message_size<midi2::ump_message_type::utility>::value);
+UMP_TUPLE(utility, delta_clockstamp)  // Define tuple_size and tuple_element for delta_clockstamp
 
 //*             _              *
 //*  ____  _ __| |_ ___ _ __   *
@@ -416,6 +367,12 @@ class midi_time_code;
 class song_position_pointer;
 class song_select;
 class tune_request;
+class timing_clock;
+class sequence_start;
+class sequence_continue;
+class sequence_stop;
+class active_sensing;
+class reset;
 
 }  // namespace midi2::types::system
 
@@ -425,7 +382,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::timing_code); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::timing_code); }
 
     using mt = details::bitfield<28U, 4U>;  ///< Always 0x1
     using group = details::bitfield<24U, 4U>;
@@ -454,18 +411,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a midi_time_code message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::system::midi_time_code>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::system::midi_time_code::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the midi_time_code message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::system::midi_time_code> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element_t<I, decltype(midi2::types::system::midi_time_code::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::system::midi_time_code> ==
-              midi2::message_size<midi2::ump_message_type::system>::value);
+UMP_TUPLE(system, midi_time_code)  // Define tuple_size and tuple_element for midi_time_code
 
 class midi2::types::system::song_position_pointer {
 public:
@@ -473,7 +419,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::spp); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::spp); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -503,20 +449,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a song_position_pointer message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::system::song_position_pointer>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::system::song_position_pointer::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the song_position_pointer message.
-template <std::size_t I>
-struct std::tuple_element<I, midi2::types::system::song_position_pointer> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element_t<I, decltype(midi2::types::system::song_position_pointer::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::system::song_position_pointer> ==
-              midi2::message_size<midi2::ump_message_type::system>::value);
+UMP_TUPLE(system, song_position_pointer)  // Define tuple_size and tuple_element for song_position_pointer
 
 class midi2::types::system::song_select {
 public:
@@ -553,18 +486,7 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a song_select as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::system::song_select>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::system::song_select::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of the song_select message..
-template <std::size_t I> struct std::tuple_element<I, midi2::types::system::song_select> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element_t<I, decltype(midi2::types::system::song_select::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::system::song_select> ==
-              midi2::message_size<midi2::ump_message_type::system>::value);
+UMP_TUPLE(system, song_select)  // Define tuple_size and tuple_element for song_select
 
 class midi2::types::system::tune_request {
 public:
@@ -598,28 +520,15 @@ private:
   std::tuple<word0> words_;
 };
 
-/// Provides access to the number of words in a song_select as a tune_request constant expression.
-template <>
-struct std::tuple_size<midi2::types::system::tune_request>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::system::tune_request::words_)>> {};
+UMP_TUPLE(system, tune_request)  // Define tuple_size and tuple_element for tune_request
 
-/// Provides compile-time indexed access to the types of the elements of the tune_request message..
-template <std::size_t I> struct std::tuple_element<I, midi2::types::system::tune_request> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element_t<I, decltype(midi2::types::system::tune_request::words_)>;
-};
-
-static_assert(std::tuple_size_v<midi2::types::system::tune_request> ==
-              midi2::message_size<midi2::ump_message_type::system>::value);
-
-namespace midi2 {
-namespace types::system {
-
-struct timing_clock {
+class midi2::types::system::timing_clock {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::timing_clock); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::timing_clock); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -628,23 +537,32 @@ struct timing_clock {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr timing_clock() = default;
-  constexpr explicit timing_clock(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(timing_clock const &, timing_clock const &) = default;
+  constexpr timing_clock() noexcept = default;
+  constexpr explicit timing_clock(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(timing_clock const &, timing_clock const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<timing_clock>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-struct sequence_start {
+UMP_TUPLE(system, timing_clock)  // Define tuple_size and tuple_element for timing_clock
+
+class midi2::types::system::sequence_start {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::sequence_start); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::sequence_start); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -653,23 +571,32 @@ struct sequence_start {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr sequence_start() = default;
-  constexpr explicit sequence_start(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(sequence_start const &, sequence_start const &) = default;
+  constexpr sequence_start() noexcept = default;
+  constexpr explicit sequence_start(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(sequence_start const &, sequence_start const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<sequence_start>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-struct sequence_continue {
+UMP_TUPLE(system, sequence_start)  // Define tuple_size and tuple_element for sequence_start
+
+class midi2::types::system::sequence_continue {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::sequence_continue); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::sequence_continue); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -678,23 +605,32 @@ struct sequence_continue {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr sequence_continue() = default;
-  constexpr explicit sequence_continue(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(sequence_continue const &, sequence_continue const &) = default;
+  constexpr sequence_continue() noexcept = default;
+  constexpr explicit sequence_continue(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(sequence_continue const &, sequence_continue const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<sequence_continue>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-struct sequence_stop {
+UMP_TUPLE(system, sequence_continue)  // Define tuple_size and tuple_element for sequence_continue
+
+class midi2::types::system::sequence_stop {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::sequence_stop); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::sequence_stop); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -703,18 +639,27 @@ struct sequence_stop {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr sequence_stop() = default;
-  constexpr explicit sequence_stop(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(sequence_stop const &, sequence_stop const &) = default;
+  constexpr sequence_stop() noexcept = default;
+  constexpr explicit sequence_stop(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(sequence_stop const &, sequence_stop const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<sequence_stop>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-struct active_sensing {
+UMP_TUPLE(system, sequence_stop)  // Define tuple_size and tuple_element for sequence_stop
+
+class midi2::types::system::active_sensing {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -736,10 +681,19 @@ struct active_sensing {
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<active_sensing>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-struct reset {
+UMP_TUPLE(system, active_sensing)  // Define tuple_size and tuple_element for active_sensing
+
+class midi2::types::system::reset {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -761,10 +715,18 @@ struct reset {
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<reset>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-}  // end namespace types::system
+UMP_TUPLE(system, reset)  // Define tuple_size and tuple_element for reset
+
+namespace midi2 {
 
 //*        _                 *
 //*  _ __ / |  ____ ___ __   *
@@ -803,7 +765,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::note_on); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::note_on); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x2 (MIDI 1.0 Channel Voice)
     using group = details::bitfield<24, 4>;
@@ -828,23 +790,14 @@ public:
 
 private:
   friend struct ::std::tuple_size<note_on>;
-  friend struct ::std::tuple_element<0, note_on>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
   std::tuple<word0> words_;
 };
 
-template <>
-struct std::tuple_size<midi2::types::m1cvm::note_on>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m1cvm::note_on::words_)>> {};
-
-template <std::size_t I> struct std::tuple_element<I, midi2::types::m1cvm::note_on> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::m1cvm::note_on::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::m1cvm::note_on> ==
-              midi2::message_size<midi2::ump_message_type::system>::value);
+UMP_TUPLE(m1cvm, note_on)  // Define tuple_size and tuple_element for m1cvm/note_on
 
 // 7.3.1 MIDI 1.0 Note Off Message
 class midi2::types::m1cvm::note_off {
@@ -853,7 +806,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::note_off); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::note_off); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x2 (MIDI 1.0 Channel Voice)
     using group = details::bitfield<24, 4>;
@@ -865,9 +818,9 @@ public:
     using velocity = details::bitfield<0, 7>;
   };
 
-  constexpr note_off() = default;
-  constexpr explicit note_off(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(note_off const &, note_off const &) = default;
+  constexpr note_off() noexcept = default;
+  constexpr explicit note_off(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(note_off const &, note_off const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -885,16 +838,7 @@ private:
   std::tuple<word0> words_;
 };
 
-template <>
-struct std::tuple_size<midi2::types::m1cvm::note_off>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m1cvm::note_off::words_)>> {};
-
-template <std::size_t I> struct std::tuple_element<I, midi2::types::m1cvm::note_off> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::m1cvm::note_off::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::m1cvm::note_on> ==
-              midi2::message_size<midi2::ump_message_type::system>::value);
+UMP_TUPLE(m1cvm, note_off)  // Define tuple_size and tuple_element for m1cvm/note_off
 
 namespace midi2 {
 namespace types::m1cvm {
@@ -3152,35 +3096,6 @@ template <> struct message_size<ump_message_type::reserved128_0E> : std::integra
 
 namespace std {
 
-template <>
-struct tuple_size<midi2::types::system::timing_clock>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::timing_clock::words_)>::value> {};
-
-template <>
-struct tuple_size<midi2::types::system::sequence_start>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::sequence_start::words_)>::value> {};
-
-template <>
-struct tuple_size<midi2::types::system::sequence_continue>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::sequence_continue::words_)>::value> {};
-
-template <>
-struct tuple_size<midi2::types::system::sequence_stop>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::sequence_stop::words_)>::value> {};
-
-template <>
-struct tuple_size<midi2::types::system::active_sensing>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::active_sensing::words_)>::value> {};
-
-template <>
-struct tuple_size<midi2::types::system::reset>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::system::reset::words_)>::value> {};
-
 template <midi2::data64 Status>
 struct tuple_size<midi2::types::data64::details::sysex7<Status>>  // NOLINT(cert-dcl58-cpp]
     : public std::integral_constant<std::size_t,
@@ -3348,5 +3263,6 @@ struct tuple_size<midi2::types::flex_data::text_common>  // NOLINT(cert-dcl58-cp
 #undef UMP_GETTER
 #undef UMP_SETTER
 #undef UMP_GETTER_SETTER
+#undef UMP_TUPLE
 
 #endif  // MIDI2_UMP_TYPES_HPP

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -135,6 +135,11 @@ private:
   UMP_GETTER(word, field)              \
   UMP_SETTER(word, field)
 
+/// This macro is used to generate boilerplate definitions of three items for the class specficied by the \p group
+/// and \p message parameters:
+/// 1. An specialization of std::tuple_size<>
+/// 2. An specialization of std::tuple_element<>
+/// 3. A static assertion that the tuple size for the class matches that of the group as a whole
 #define UMP_TUPLE(group, message)                                                                                    \
   template <>                                                                                                        \
   struct std::tuple_size<midi2::types::group::message> /* NOLINT(cert-dcl58-cpp]*/                                   \
@@ -749,11 +754,11 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
 
 class note_on;
 class note_off;
-struct poly_pressure;
-struct control_change;
-struct program_change;
-struct channel_pressure;
-struct pitch_bend;
+class poly_pressure;
+class control_change;
+class program_change;
+class channel_pressure;
+class pitch_bend;
 
 }  // end namespace types::m1cvm
 }  // end namespace midi2
@@ -840,16 +845,14 @@ private:
 
 UMP_TUPLE(m1cvm, note_off)  // Define tuple_size and tuple_element for m1cvm/note_off
 
-namespace midi2 {
-namespace types::m1cvm {
-
 // 7.3.3 MIDI 1.0 Poly Pressure Message
-struct poly_pressure {
+class midi2::types::m1cvm::poly_pressure {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::poly_pressure); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::poly_pressure); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x2 (MIDI 1.0 Channel Voice)
     using group = details::bitfield<24, 4>;
@@ -861,9 +864,9 @@ struct poly_pressure {
     using pressure = details::bitfield<0, 7>;
   };
 
-  constexpr poly_pressure() = default;
-  constexpr explicit poly_pressure(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(poly_pressure const &, poly_pressure const &) = default;
+  constexpr poly_pressure() noexcept = default;
+  constexpr explicit poly_pressure(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(poly_pressure const &, poly_pressure const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER(word0, status)
@@ -872,16 +875,25 @@ struct poly_pressure {
   UMP_GETTER_SETTER(word0, note)
   UMP_GETTER_SETTER(word0, pressure)
 
+private:
+  friend struct ::std::tuple_size<poly_pressure>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
+UMP_TUPLE(m1cvm, poly_pressure)  // Define tuple_size and tuple_element for m1cvm/poly_pressure
+
 // 7.3.4 MIDI 1.0 Control Change Message
-struct control_change {
+class midi2::types::m1cvm::control_change {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::cc); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::cc); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x2 (MIDI 1.0 Channel Voice)
     using group = details::bitfield<24, 4>;
@@ -893,9 +905,9 @@ struct control_change {
     using value = details::bitfield<0, 7>;
   };
 
-  constexpr control_change() = default;
-  constexpr explicit control_change(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(control_change const &, control_change const &) = default;
+  constexpr control_change() noexcept = default;
+  constexpr explicit control_change(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(control_change const &, control_change const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -904,16 +916,25 @@ struct control_change {
   UMP_GETTER_SETTER(word0, controller)
   UMP_GETTER_SETTER(word0, value)
 
+private:
+  friend struct ::std::tuple_size<control_change>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
+UMP_TUPLE(m1cvm, control_change)  // Define tuple_size and tuple_element for m1cvm/control_change
+
 // 7.3.5 MIDI 1.0 Program Change Message
-struct program_change {
+class midi2::types::m1cvm::program_change {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::program_change); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::program_change); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x2 (MIDI 1.0 Channel Voice)
     using group = details::bitfield<24, 4>;
@@ -924,9 +945,9 @@ struct program_change {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr program_change() = default;
-  constexpr explicit program_change(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(program_change const &, program_change const &) = default;
+  constexpr program_change() noexcept = default;
+  constexpr explicit program_change(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(program_change const &, program_change const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -934,16 +955,25 @@ struct program_change {
   UMP_GETTER_SETTER(word0, channel)
   UMP_GETTER_SETTER(word0, program)
 
+private:
+  friend struct ::std::tuple_size<program_change>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
+UMP_TUPLE(m1cvm, program_change)  // Define tuple_size and tuple_element for m1cvm/program_change
+
 // 7.3.6 MIDI 1.0 Channel Pressure Message
-struct channel_pressure {
+class midi2::types::m1cvm::channel_pressure {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::channel_pressure); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::channel_pressure); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x2 (MIDI 1.0 Channel Voice)
     using group = details::bitfield<24, 4>;
@@ -954,9 +984,9 @@ struct channel_pressure {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr channel_pressure() = default;
-  constexpr explicit channel_pressure(std::uint32_t const w0_) : words_{w0_} {}
-  friend constexpr bool operator==(channel_pressure const &, channel_pressure const &) = default;
+  constexpr channel_pressure() noexcept = default;
+  constexpr explicit channel_pressure(std::uint32_t const w0_) noexcept : words_{w0_} {}
+  friend constexpr bool operator==(channel_pressure const &, channel_pressure const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -964,16 +994,25 @@ struct channel_pressure {
   UMP_GETTER_SETTER(word0, channel)
   UMP_GETTER_SETTER(word0, data)
 
+private:
+  friend struct ::std::tuple_size<channel_pressure>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
+UMP_TUPLE(m1cvm, channel_pressure)  // Define tuple_size and tuple_element for m1cvm/channel_pressure
+
 // 7.3.7 MIDI 1.0 Pitch Bend Message
-struct pitch_bend {
+class midi2::types::m1cvm::pitch_bend {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::status::pitch_bend); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::status::pitch_bend); }
 
     using mt = details::bitfield<28, 4>;  // 0x2
     using group = details::bitfield<24, 4>;
@@ -984,9 +1023,9 @@ struct pitch_bend {
     using reserved1 = details::bitfield<7, 1>;
     using msb_data = details::bitfield<0, 7>;
   };
-  constexpr pitch_bend() = default;
-  constexpr explicit pitch_bend(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(pitch_bend const &, pitch_bend const &) = default;
+  constexpr pitch_bend() noexcept = default;
+  constexpr explicit pitch_bend(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(pitch_bend const &, pitch_bend const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -995,16 +1034,24 @@ struct pitch_bend {
   UMP_GETTER_SETTER(word0, lsb_data)
   UMP_GETTER_SETTER(word0, msb_data)
 
+private:
+  friend struct ::std::tuple_size<pitch_bend>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-}  // end namespace types::m1cvm
+UMP_TUPLE(m1cvm, pitch_bend)  // Define tuple_size and tuple_element for m1cvm/pitch_bend
 
 //*     _      _         __ _ _   *
 //*  __| |__ _| |_ __ _ / /| | |  *
 //* / _` / _` |  _/ _` / _ \_  _| *
 //* \__,_\__,_|\__\__,_\___/ |_|  *
 //*                               *
+
+namespace midi2 {
 
 template <> struct message_size<ump_message_type::data64> : std::integral_constant<unsigned, 2> {};
 
@@ -3100,26 +3147,6 @@ template <midi2::data64 Status>
 struct tuple_size<midi2::types::data64::details::sysex7<Status>>  // NOLINT(cert-dcl58-cpp]
     : public std::integral_constant<std::size_t,
                                     tuple_size_v<decltype(midi2::types::data64::details::sysex7<Status>::words_)>> {};
-
-template <>
-struct tuple_size<midi2::types::m1cvm::poly_pressure>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m1cvm::poly_pressure::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m1cvm::program_change>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m1cvm::program_change::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m1cvm::channel_pressure>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m1cvm::channel_pressure::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m1cvm::control_change>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m1cvm::control_change::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m1cvm::pitch_bend>
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m1cvm::pitch_bend::words_)>::value> {};
 
 template <>
 struct tuple_size<midi2::types::m2cvm::program_change>

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -20,8 +20,7 @@
 
 #include "midi2/utils.hpp"
 
-namespace midi2 {
-namespace types {
+namespace midi2::types {
 
 template <typename T>
 concept bitfield_type = requires(T) {
@@ -119,8 +118,7 @@ private:
 
 }  // end namespace details
 
-}  // end namespace types
-}  // end namespace midi2
+}  // end namespace midi2::types
 
 #define UMP_GETTER(word, field)                                         \
   constexpr auto field() const noexcept {                               \

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -161,6 +161,7 @@ class jr_clock;
 class jr_timestamp;
 class delta_clockstamp_tpqn;
 class delta_clockstamp;
+class song_position_pointer;
 
 }  // end namespace midi2::types::utility
 
@@ -186,7 +187,7 @@ public:
 
 private:
   friend struct ::std::tuple_size<noop>;
-  friend struct ::std::tuple_element<0, noop>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
@@ -199,8 +200,8 @@ struct std::tuple_size<midi2::types::utility::noop>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::utility::noop::words_)>::value> {};
 
 /// Provides compile-time indexed access to the types of the elements of the noop message.
-template <> struct std::tuple_element<0, midi2::types::utility::noop> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<0, decltype(midi2::types::utility::noop::words_)>::type;
+template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::noop> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::utility::noop::words_)>::type;
 };
 
 static_assert(std::tuple_size_v<midi2::types::utility::noop> ==
@@ -232,7 +233,7 @@ public:
 
 private:
   friend struct ::std::tuple_size<jr_clock>;
-  friend struct ::std::tuple_element<0, jr_clock>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
@@ -245,8 +246,8 @@ struct std::tuple_size<midi2::types::utility::jr_clock>  // NOLINT(cert-dcl58-cp
     : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::utility::jr_clock::words_)>::value> {};
 
 /// Provides compile-time indexed access to the types of the elements of the jr_clock message.
-template <> struct std::tuple_element<0, midi2::types::utility::jr_clock> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<0, decltype(midi2::types::utility::jr_clock::words_)>::type;
+template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::jr_clock> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::utility::jr_clock::words_)>::type;
 };
 
 static_assert(std::tuple_size_v<midi2::types::utility::jr_clock> ==
@@ -278,6 +279,7 @@ public:
 
 private:
   friend struct ::std::tuple_size<jr_timestamp>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
@@ -291,8 +293,8 @@ struct std::tuple_size<midi2::types::utility::jr_timestamp>  // NOLINT(cert-dcl5
                              std::tuple_size<decltype(midi2::types::utility::jr_timestamp::words_)>::value> {};
 
 /// Provides compile-time indexed access to the types of the elements of the jr_timestamp message.
-template <> struct std::tuple_element<0, midi2::types::utility::jr_timestamp> {  // NOLINT(cert-dcl58-cpp]
-  using type = midi2::types::utility::jr_timestamp::word0;
+template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::jr_timestamp> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::utility::jr_timestamp::words_)>;
 };
 
 static_assert(std::tuple_size_v<midi2::types::utility::jr_timestamp> ==
@@ -324,6 +326,7 @@ public:
 
 private:
   friend struct ::std::tuple_size<delta_clockstamp_tpqn>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
@@ -337,8 +340,9 @@ struct std::tuple_size<midi2::types::utility::delta_clockstamp_tpqn>  // NOLINT(
                              std::tuple_size<decltype(midi2::types::utility::delta_clockstamp_tpqn::words_)>::value> {};
 
 /// Provides compile-time indexed access to the types of the elements of the delta_clockstamp_tpqn message.
-template <> struct std::tuple_element<0, midi2::types::utility::delta_clockstamp_tpqn> {  // NOLINT(cert-dcl58-cpp]
-  using type = midi2::types::utility::delta_clockstamp_tpqn::word0;
+template <std::size_t I>
+struct std::tuple_element<I, midi2::types::utility::delta_clockstamp_tpqn> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::utility::delta_clockstamp_tpqn::words_)>;
 };
 
 static_assert(std::tuple_size_v<midi2::types::utility::delta_clockstamp_tpqn> ==
@@ -351,7 +355,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(ump_utility::delta_clock_since); }
+    constexpr word0() noexcept { this->init<mt, status>(ump_utility::delta_clock_since); }
 
     using mt = details::bitfield<28, 4>;  // 0x0
     using reserved0 = details::bitfield<24, 4>;
@@ -359,9 +363,9 @@ public:
     using ticks_per_quarter_note = details::bitfield<0, 20>;
   };
 
-  constexpr delta_clockstamp() = default;
-  constexpr explicit delta_clockstamp(std::uint32_t const w0_) : words_{w0_} {}
-  friend constexpr bool operator==(delta_clockstamp const &, delta_clockstamp const &) = default;
+  constexpr delta_clockstamp() noexcept = default;
+  constexpr explicit delta_clockstamp(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(delta_clockstamp const &, delta_clockstamp const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER(word0, status)
@@ -369,6 +373,7 @@ public:
 
 private:
   friend struct ::std::tuple_size<delta_clockstamp>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
@@ -382,8 +387,9 @@ struct std::tuple_size<midi2::types::utility::delta_clockstamp>  // NOLINT(cert-
                              std::tuple_size<decltype(midi2::types::utility::delta_clockstamp::words_)>::value> {};
 
 /// Provides compile-time indexed access to the types of the elements of the delta_clockstamp message.
-template <> struct std::tuple_element<0, midi2::types::utility::delta_clockstamp> {  // NOLINT(cert-dcl58-cpp]
-  using type = midi2::types::utility::delta_clockstamp::word0;
+template <std::size_t I>
+struct std::tuple_element<I, midi2::types::utility::delta_clockstamp> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element_t<I, decltype(midi2::types::utility::delta_clockstamp::words_)>;
 };
 
 static_assert(std::tuple_size_v<midi2::types::utility::delta_clockstamp> ==
@@ -408,6 +414,7 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
 }
 
 class midi_time_code;
+class song_position_pointer;
 
 }  // namespace midi2::types::system
 
@@ -439,6 +446,7 @@ public:
 
 private:
   friend struct ::std::tuple_size<midi_time_code>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
   template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
   template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
@@ -452,17 +460,15 @@ struct std::tuple_size<midi2::types::system::midi_time_code>  // NOLINT(cert-dcl
                              std::tuple_size<decltype(midi2::types::system::midi_time_code::words_)>::value> {};
 
 /// Provides compile-time indexed access to the types of the elements of the midi_time_code message.
-template <> struct std::tuple_element<0, midi2::types::system::midi_time_code> {  // NOLINT(cert-dcl58-cpp]
-  using type = midi2::types::system::midi_time_code::word0;
+template <std::size_t I> struct std::tuple_element<I, midi2::types::system::midi_time_code> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element_t<I, decltype(midi2::types::system::midi_time_code::words_)>;
 };
 
-static_assert(std::tuple_size_v<midi2::types::utility::delta_clockstamp> ==
+static_assert(std::tuple_size_v<midi2::types::system::midi_time_code> ==
               midi2::message_size<midi2::ump_message_type::system>::value);
 
-namespace midi2 {
-namespace types::system {
-
-struct song_position_pointer {
+class midi2::types::system::song_position_pointer {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -478,9 +484,9 @@ struct song_position_pointer {
     using position_msb = details::bitfield<0, 7>;
   };
 
-  constexpr song_position_pointer() = default;
-  constexpr explicit song_position_pointer(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(song_position_pointer const &, song_position_pointer const &) = default;
+  constexpr song_position_pointer() noexcept = default;
+  constexpr explicit song_position_pointer(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(song_position_pointer const &, song_position_pointer const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -488,8 +494,32 @@ struct song_position_pointer {
   UMP_GETTER_SETTER(word0, position_lsb)
   UMP_GETTER_SETTER(word0, position_msb)
 
+private:
+  friend struct ::std::tuple_size<song_position_pointer>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
+
+/// Provides access to the number of words in a song_position_pointer message as a compile-time constant expression.
+template <>
+struct std::tuple_size<midi2::types::system::song_position_pointer>  // NOLINT(cert-dcl58-cpp]
+    : std::integral_constant<std::size_t,
+                             std::tuple_size<decltype(midi2::types::system::song_position_pointer::words_)>::value> {};
+
+/// Provides compile-time indexed access to the types of the elements of the song_position_pointer message.
+template <std::size_t I>
+struct std::tuple_element<I, midi2::types::system::song_position_pointer> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element_t<I, decltype(midi2::types::system::midi_time_code::words_)>;
+};
+
+static_assert(std::tuple_size_v<midi2::types::system::song_position_pointer> ==
+              midi2::message_size<midi2::ump_message_type::system>::value);
+
+namespace midi2 {
+namespace types::system {
 
 struct song_select {
   class word0 : public details::word_base {
@@ -716,7 +746,7 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
 }
 
 class note_on;
-struct note_off;
+class note_off;
 struct poly_pressure;
 struct control_change;
 struct program_change;
@@ -745,9 +775,9 @@ public:
     using velocity = details::bitfield<0, 7>;
   };
 
-  constexpr note_on() = default;
-  constexpr explicit note_on(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(note_on const &, note_on const &) = default;
+  constexpr note_on() noexcept = default;
+  constexpr explicit note_on(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(note_on const &, note_on const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -755,6 +785,12 @@ public:
   UMP_GETTER_SETTER(word0, channel)
   UMP_GETTER_SETTER(word0, note)
   UMP_GETTER_SETTER(word0, velocity)
+
+private:
+  friend struct ::std::tuple_size<note_on>;
+  friend struct ::std::tuple_element<0, note_on>;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
 
   std::tuple<word0> words_;
 };
@@ -770,11 +806,9 @@ template <std::size_t I> struct std::tuple_element<I, midi2::types::m1cvm::note_
 static_assert(std::tuple_size_v<midi2::types::m1cvm::note_on> ==
               midi2::message_size<midi2::ump_message_type::system>::value);
 
-namespace midi2 {
-namespace types::m1cvm {
-
 // 7.3.1 MIDI 1.0 Note Off Message
-struct note_off {
+class midi2::types::m1cvm::note_off {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -802,8 +836,28 @@ struct note_off {
   UMP_GETTER_SETTER(word0, note)
   UMP_GETTER_SETTER(word0, velocity)
 
+private:
+  friend struct ::std::tuple_size<note_off>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
+
+template <>
+struct std::tuple_size<midi2::types::m1cvm::note_off>  // NOLINT(cert-dcl58-cpp]
+    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m1cvm::note_off::words_)>::value> {};
+
+template <std::size_t I> struct std::tuple_element<I, midi2::types::m1cvm::note_off> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::m1cvm::note_off::words_)>::type;
+};
+
+static_assert(std::tuple_size_v<midi2::types::m1cvm::note_on> ==
+              midi2::message_size<midi2::ump_message_type::system>::value);
+
+namespace midi2 {
+namespace types::m1cvm {
 
 // 7.3.3 MIDI 1.0 Poly Pressure Message
 struct poly_pressure {
@@ -1068,8 +1122,8 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
 
 class note_off;
 class note_on;
-struct poly_pressure;
-struct rpn_per_note_controller;
+class poly_pressure;
+class rpn_per_note_controller;
 struct nrpn_per_note_controller;
 struct rpn_controller;
 struct nrpn_controller;
@@ -1191,12 +1245,12 @@ private:
   std::tuple<word0, word1> words_;
 };
 
-/// Provides access to the number of words in a MIDI 2 note-off message as a compile-time constant expression.
+/// Provides access to the number of words in a MIDI 2 note-on message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::m2cvm::note_on>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m2cvm::note_on::words_)>::value> {};
 
-/// Provides compile-time indexed access to the types of the elements of MIDI 2 note-off message.
+/// Provides compile-time indexed access to the types of the elements of MIDI 2 note-on message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::note_on> {  // NOLINT(cert-dcl58-cpp]
   using type = std::tuple_element<I, decltype(midi2::types::m2cvm::note_on::words_)>::type;
 };
@@ -1204,11 +1258,9 @@ template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::note_
 static_assert(std::tuple_size_v<midi2::types::m2cvm::note_on> ==
               midi2::message_size<midi2::ump_message_type::m2cvm>::value);
 
-namespace midi2 {
-namespace types::m2cvm {
-
 // 7.4.3 MIDI 2.0 Poly Pressure Message
-struct poly_pressure {
+class midi2::types::m2cvm::poly_pressure {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -1229,9 +1281,9 @@ struct poly_pressure {
     using pressure = details::bitfield<0, 32>;
   };
 
-  constexpr poly_pressure() = default;
-  constexpr explicit poly_pressure(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(poly_pressure const &a, poly_pressure const &b) = default;
+  constexpr poly_pressure() noexcept = default;
+  constexpr explicit poly_pressure(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(poly_pressure const &a, poly_pressure const &b) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1240,11 +1292,32 @@ struct poly_pressure {
   UMP_GETTER_SETTER(word0, note)
   UMP_GETTER_SETTER(word1, pressure)
 
+private:
+  friend struct ::std::tuple_size<poly_pressure>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+/// Provides access to the number of words in a MIDI 2 poly-pressure message as a compile-time constant expression.
+template <>
+struct std::tuple_size<midi2::types::m2cvm::poly_pressure>  // NOLINT(cert-dcl58-cpp]
+    : std::integral_constant<std::size_t,
+                             std::tuple_size<decltype(midi2::types::m2cvm::poly_pressure::words_)>::value> {};
+
+/// Provides compile-time indexed access to the types of the elements of MIDI 2 poly-pressure message.
+template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::poly_pressure> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::m2cvm::poly_pressure::words_)>::type;
+};
+
+static_assert(std::tuple_size_v<midi2::types::m2cvm::poly_pressure> ==
+              midi2::message_size<midi2::ump_message_type::m2cvm>::value);
+
 // 7.4.4 MIDI 2.0 Registered Per-Note Controller Messages
-struct rpn_per_note_controller {
+class midi2::types::m2cvm::rpn_per_note_controller {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -1263,9 +1336,10 @@ struct rpn_per_note_controller {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr rpn_per_note_controller() = default;
-  constexpr explicit rpn_per_note_controller(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(rpn_per_note_controller const &a, rpn_per_note_controller const &b) = default;
+  constexpr rpn_per_note_controller() noexcept = default;
+  constexpr explicit rpn_per_note_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(rpn_per_note_controller const &a,
+                                   rpn_per_note_controller const &b) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1276,8 +1350,32 @@ struct rpn_per_note_controller {
   UMP_GETTER_SETTER(word0, index)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<rpn_per_note_controller>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
+
+/// Provides access to the number of words in a MIDI 2 poly-pressure message as a compile-time constant expression.
+template <>
+struct std::tuple_size<midi2::types::m2cvm::rpn_per_note_controller>  // NOLINT(cert-dcl58-cpp]
+    : std::integral_constant<std::size_t,
+                             std::tuple_size<decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>::value> {};
+
+/// Provides compile-time indexed access to the types of the elements of MIDI 2 poly-pressure message.
+template <std::size_t I>
+struct std::tuple_element<I, midi2::types::m2cvm::rpn_per_note_controller> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element<I, decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>::type;
+};
+
+static_assert(std::tuple_size_v<midi2::types::m2cvm::rpn_per_note_controller> ==
+              midi2::message_size<midi2::ump_message_type::m2cvm>::value);
+
+namespace midi2 {
+namespace types::m2cvm {
 
 // 7.4.4 MIDI 2.0 Assignable Per-Note Controller Messages
 struct nrpn_per_note_controller {
@@ -3016,10 +3114,6 @@ template <> struct message_size<ump_message_type::reserved128_0E> : std::integra
 namespace std {
 
 template <>
-struct tuple_size<midi2::types::system::song_position_pointer>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::song_position_pointer::words_)>::value> {};
-template <>
 struct tuple_size<midi2::types::system::song_select>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::system::song_select::words_)>::value> {
 };
@@ -3062,9 +3156,6 @@ struct tuple_size<midi2::types::data64::details::sysex7<Status>>  // NOLINT(cert
                                     tuple_size_v<decltype(midi2::types::data64::details::sysex7<Status>::words_)>> {};
 
 template <>
-struct tuple_size<midi2::types::m1cvm::note_off>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m1cvm::note_off::words_)>::value> {};
-template <>
 struct tuple_size<midi2::types::m1cvm::poly_pressure>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t,
                              std::tuple_size<decltype(midi2::types::m1cvm::poly_pressure::words_)>::value> {};
@@ -3085,10 +3176,6 @@ struct tuple_size<midi2::types::m1cvm::pitch_bend>
     : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m1cvm::pitch_bend::words_)>::value> {};
 
 template <>
-struct tuple_size<midi2::types::m2cvm::poly_pressure>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::poly_pressure::words_)>::value> {};
-template <>
 struct tuple_size<midi2::types::m2cvm::program_change>
     : std::integral_constant<std::size_t,
                              std::tuple_size<decltype(midi2::types::m2cvm::program_change::words_)>::value> {};
@@ -3104,10 +3191,6 @@ template <>
 struct tuple_size<midi2::types::m2cvm::nrpn_controller>
     : std::integral_constant<std::size_t,
                              std::tuple_size<decltype(midi2::types::m2cvm::nrpn_controller::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::rpn_per_note_controller>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>::value> {};
 template <>
 struct tuple_size<midi2::types::m2cvm::nrpn_per_note_controller>
     : std::integral_constant<std::size_t,

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -669,7 +669,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::active_sensing); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::active_sensing); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -678,9 +678,9 @@ public:
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr active_sensing() = default;
-  constexpr explicit active_sensing(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(active_sensing const &, active_sensing const &) = default;
+  constexpr active_sensing() noexcept = default;
+  constexpr explicit active_sensing(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(active_sensing const &, active_sensing const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -703,7 +703,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::system_reset); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::system_reset); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -712,9 +712,9 @@ public:
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr reset() = default;
-  constexpr explicit reset(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(reset const &, reset const &) = default;
+  constexpr reset() noexcept = default;
+  constexpr explicit reset(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(reset const &, reset const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1176,17 +1176,17 @@ class note_off;
 class note_on;
 class poly_pressure;
 class rpn_per_note_controller;
-struct nrpn_per_note_controller;
-struct rpn_controller;
-struct nrpn_controller;
-struct rpn_relative_controller;
-struct nrpn_relative_controller;
-struct per_note_management;
-struct control_change;
-struct program_change;
-struct channel_pressure;
-struct pitch_bend;
-struct per_note_pitch_bend;
+class nrpn_per_note_controller;
+class rpn_controller;
+class nrpn_controller;
+class rpn_relative_controller;
+class nrpn_relative_controller;
+class per_note_management;
+class control_change;
+class program_change;
+class channel_pressure;
+class pitch_bend;
+class per_note_pitch_bend;
 
 }  // end namespace midi2::types::m2cvm
 
@@ -1197,7 +1197,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::note_off); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::note_off); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1237,18 +1237,7 @@ private:
   std::tuple<word0, word1> words_;
 };
 
-/// Provides access to the number of words in a MIDI 2 note-off message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::m2cvm::note_off>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m2cvm::note_off::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of MIDI 2 note-off message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::note_off> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::m2cvm::note_off::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::m2cvm::note_off> ==
-              midi2::message_size<midi2::ump_message_type::m2cvm>::value);
+UMP_TUPLE(m2cvm, note_off)  // Define tuple_size and tuple_element for m2cvm/note_off
 
 // 7.4.2 MIDI 2.0 Note On Message
 class midi2::types::m2cvm::note_on {
@@ -1257,7 +1246,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::note_on); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::note_on); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1297,18 +1286,7 @@ private:
   std::tuple<word0, word1> words_;
 };
 
-/// Provides access to the number of words in a MIDI 2 note-on message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::m2cvm::note_on>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m2cvm::note_on::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of MIDI 2 note-on message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::note_on> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::m2cvm::note_on::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::m2cvm::note_on> ==
-              midi2::message_size<midi2::ump_message_type::m2cvm>::value);
+UMP_TUPLE(m2cvm, note_on)  // Define tuple_size and tuple_element for m2cvm/note_on
 
 // 7.4.3 MIDI 2.0 Poly Pressure Message
 class midi2::types::m2cvm::poly_pressure {
@@ -1317,7 +1295,7 @@ public:
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::poly_pressure); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::poly_pressure); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1353,18 +1331,7 @@ private:
   std::tuple<word0, word1> words_;
 };
 
-/// Provides access to the number of words in a MIDI 2 poly-pressure message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::m2cvm::poly_pressure>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m2cvm::poly_pressure::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of MIDI 2 poly-pressure message.
-template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::poly_pressure> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::m2cvm::poly_pressure::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::m2cvm::poly_pressure> ==
-              midi2::message_size<midi2::ump_message_type::m2cvm>::value);
+UMP_TUPLE(m2cvm, poly_pressure)  // Define tuple_size and tuple_element for m2cvm/poly_pressure
 
 // 7.4.4 MIDI 2.0 Registered Per-Note Controller Messages
 class midi2::types::m2cvm::rpn_per_note_controller {
@@ -1372,7 +1339,7 @@ public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::rpn_pernote); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::rpn_pernote); }
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
     using status = details::bitfield<20, 4>;  ///< Registered Per-Note Controller=0x0
@@ -1389,8 +1356,7 @@ public:
 
   constexpr rpn_per_note_controller() noexcept = default;
   constexpr explicit rpn_per_note_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(rpn_per_note_controller const &a,
-                                   rpn_per_note_controller const &b) noexcept = default;
+  friend constexpr bool operator==(rpn_per_note_controller const &, rpn_per_note_controller const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1410,31 +1376,16 @@ private:
   std::tuple<word0, word1> words_;
 };
 
-/// Provides access to the number of words in a MIDI 2 poly-pressure message as a compile-time constant expression.
-template <>
-struct std::tuple_size<midi2::types::m2cvm::rpn_per_note_controller>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>> {};
-
-/// Provides compile-time indexed access to the types of the elements of MIDI 2 poly-pressure message.
-template <std::size_t I>
-struct std::tuple_element<I, midi2::types::m2cvm::rpn_per_note_controller> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element<I, decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>::type;
-};
-
-static_assert(std::tuple_size_v<midi2::types::m2cvm::rpn_per_note_controller> ==
-              midi2::message_size<midi2::ump_message_type::m2cvm>::value);
-
-namespace midi2 {
-namespace types::m2cvm {
+UMP_TUPLE(m2cvm, rpn_per_note_controller)  // Define tuple_size and tuple_element for m2cvm/rpn_per_note_controller
 
 // 7.4.4 MIDI 2.0 Assignable Per-Note Controller Messages
-struct nrpn_per_note_controller {
+class midi2::types::m2cvm::nrpn_per_note_controller {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::nrpn_pernote); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::nrpn_pernote); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1450,9 +1401,10 @@ struct nrpn_per_note_controller {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr nrpn_per_note_controller() = default;
-  constexpr explicit nrpn_per_note_controller(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(nrpn_per_note_controller const &a, nrpn_per_note_controller const &b) = default;
+  constexpr nrpn_per_note_controller() noexcept = default;
+  constexpr explicit nrpn_per_note_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(nrpn_per_note_controller const &,
+                                   nrpn_per_note_controller const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1463,20 +1415,29 @@ struct nrpn_per_note_controller {
   UMP_GETTER_SETTER(word0, index)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<nrpn_per_note_controller>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
+
+UMP_TUPLE(m2cvm, nrpn_per_note_controller)  // Define tuple_size and tuple_element for m2cvm/nrpn_per_note_controller
 
 // 7.4.7 MIDI 2.0 Registered Controller (RPN) Message
 /// "Registered Controllers have specific functions defined by MMA/AMEI specifications. Registered Controllers
 /// map and translate directly to MIDI 1.0 Registered Parameter Numbers and use the same
 /// definitions as MMA/AMEI approved RPN messages. Registered Controllers are organized in 128 Banks
 /// (corresponds to RPN MSB), with 128 controllers per Bank (corresponds to RPN LSB).
-struct rpn_controller {
+class midi2::types::m2cvm::rpn_controller {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::rpn); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::rpn); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1493,9 +1454,9 @@ struct rpn_controller {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr rpn_controller() = default;
-  constexpr explicit rpn_controller(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(rpn_controller const &a, rpn_controller const &b) = default;
+  constexpr rpn_controller() noexcept = default;
+  constexpr explicit rpn_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(rpn_controller const &, rpn_controller const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER(word0, status)
@@ -1505,16 +1466,25 @@ struct rpn_controller {
   UMP_GETTER_SETTER(word0, index)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<rpn_controller>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, rpn_controller)  // Define tuple_size and tuple_element for m2cvm/nrpn_per_note_controller
+
 // 7.4.7 MIDI 2.0 Assignable Controller (NRPN) Message
-struct nrpn_controller {
+class midi2::types::m2cvm::nrpn_controller {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::nrpn); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::nrpn); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1531,9 +1501,9 @@ struct nrpn_controller {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr nrpn_controller() = default;
-  constexpr explicit nrpn_controller(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(nrpn_controller const &a, nrpn_controller const &b) = default;
+  constexpr nrpn_controller() noexcept = default;
+  constexpr explicit nrpn_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(nrpn_controller const &, nrpn_controller const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1543,16 +1513,25 @@ struct nrpn_controller {
   UMP_GETTER_SETTER(word0, index)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<nrpn_controller>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, nrpn_controller)  // Define tuple_size and tuple_element for m2cvm/nrpn_controller
+
 // 7.4.8 MIDI 2.0 Relative Registered Controller (RPN) Message
-struct rpn_relative_controller {
+class midi2::types::m2cvm::rpn_relative_controller {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::rpn_relative); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::rpn_relative); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1569,9 +1548,9 @@ struct rpn_relative_controller {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr rpn_relative_controller() = default;
-  constexpr explicit rpn_relative_controller(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(rpn_relative_controller const &a, rpn_relative_controller const &b) = default;
+  constexpr rpn_relative_controller() noexcept = default;
+  constexpr explicit rpn_relative_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(rpn_relative_controller const &, rpn_relative_controller const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1581,15 +1560,24 @@ struct rpn_relative_controller {
   UMP_GETTER_SETTER(word0, index)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<rpn_relative_controller>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, rpn_relative_controller)  // Define tuple_size and tuple_element for m2cvm/rpn_relative_controller
+
 // 7.4.8 MIDI 2.0 Assignable Controller (NRPN) Message
-struct nrpn_relative_controller {
+class midi2::types::m2cvm::nrpn_relative_controller {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::nrpn_relative); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::nrpn_relative); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1606,9 +1594,10 @@ struct nrpn_relative_controller {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr nrpn_relative_controller() = default;
-  constexpr explicit nrpn_relative_controller(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(nrpn_relative_controller const &a, nrpn_relative_controller const &b) = default;
+  constexpr nrpn_relative_controller() noexcept = default;
+  constexpr explicit nrpn_relative_controller(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(nrpn_relative_controller const &,
+                                   nrpn_relative_controller const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1620,15 +1609,24 @@ struct nrpn_relative_controller {
   UMP_GETTER_SETTER(word0, index)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<nrpn_relative_controller>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, nrpn_relative_controller)  // Define tuple_size and tuple_element for m2cvm/rpn_relative_controller
+
 // 7.4.5 MIDI 2.0 Per-Note Management Message
-struct per_note_management {
+class midi2::types::m2cvm::per_note_management {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::pernote_manage); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::pernote_manage); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1646,9 +1644,9 @@ struct per_note_management {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr per_note_management() = default;
-  constexpr explicit per_note_management(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(per_note_management const &a, per_note_management const &b) = default;
+  constexpr per_note_management() noexcept = default;
+  constexpr explicit per_note_management(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(per_note_management const &, per_note_management const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1661,16 +1659,25 @@ struct per_note_management {
   UMP_GETTER_SETTER(word0, set_to_default)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<per_note_management>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, per_note_management)  // Define tuple_size and tuple_element for m2cvm/per_note_management
+
 // 7.4.6 MIDI 2.0 Control Change Message
-struct control_change {
+class midi2::types::m2cvm::control_change {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::cc); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::cc); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1686,9 +1693,9 @@ struct control_change {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr control_change() = default;
-  constexpr explicit control_change(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(control_change const &a, control_change const &b) = default;
+  constexpr control_change() noexcept = default;
+  constexpr explicit control_change(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(control_change const &, control_change const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1697,16 +1704,25 @@ struct control_change {
   UMP_GETTER_SETTER(word0, controller)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<control_change>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, control_change)  // Define tuple_size and tuple_element for m2cvm/control_change
+
 // 7.4.9 MIDI 2.0 Program Change Message
-struct program_change {
+class midi2::types::m2cvm::program_change {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::program_change); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::program_change); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1728,9 +1744,9 @@ struct program_change {
     using bank_lsb = details::bitfield<0, 7>;
   };
 
-  constexpr program_change() = default;
-  constexpr explicit program_change(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(program_change const &a, program_change const &b) = default;
+  constexpr program_change() noexcept = default;
+  constexpr explicit program_change(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(program_change const &, program_change const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1742,16 +1758,25 @@ struct program_change {
   UMP_GETTER_SETTER(word1, bank_msb)
   UMP_GETTER_SETTER(word1, bank_lsb)
 
+private:
+  friend struct ::std::tuple_size<program_change>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, program_change)  // Define tuple_size and tuple_element for m2cvm/program_change
+
 // 7.4.10 MIDI 2.0 Channel Pressure Message
-struct channel_pressure {
+class midi2::types::m2cvm::channel_pressure {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::channel_pressure); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::channel_pressure); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1766,9 +1791,9 @@ struct channel_pressure {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr channel_pressure() = default;
-  constexpr explicit channel_pressure(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(channel_pressure const &a, channel_pressure const &b) = default;
+  constexpr channel_pressure() noexcept = default;
+  constexpr explicit channel_pressure(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(channel_pressure const &, channel_pressure const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1776,16 +1801,25 @@ struct channel_pressure {
   UMP_GETTER_SETTER(word0, channel)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<channel_pressure>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, channel_pressure)  // Define tuple_size and tuple_element for m2cvm/channel_pressure
+
 // 7.4.11 MIDI 2.0 Pitch Bend Message
-struct pitch_bend {
+class midi2::types::m2cvm::pitch_bend {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::pitch_bend); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::pitch_bend); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1800,9 +1834,9 @@ struct pitch_bend {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr pitch_bend() = default;
-  constexpr explicit pitch_bend(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(pitch_bend const &a, pitch_bend const &b) = default;
+  constexpr pitch_bend() noexcept = default;
+  constexpr explicit pitch_bend(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(pitch_bend const &a, pitch_bend const &b) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1810,16 +1844,25 @@ struct pitch_bend {
   UMP_GETTER_SETTER(word0, channel)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<pitch_bend>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
+UMP_TUPLE(m2cvm, pitch_bend)  // Define tuple_size and tuple_element for m2cvm/pitch_bend
+
 // 7.4.12 MIDI 2.0 Per-Note Pitch Bend Message
-struct per_note_pitch_bend {
+class midi2::types::m2cvm::per_note_pitch_bend {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::m2cvm::pitch_bend_pernote); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::m2cvm::pitch_bend_pernote); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x4
     using group = details::bitfield<24, 4>;
@@ -1835,9 +1878,9 @@ struct per_note_pitch_bend {
     using value = details::bitfield<0, 32>;
   };
 
-  constexpr per_note_pitch_bend() = default;
-  constexpr explicit per_note_pitch_bend(std::span<std::uint32_t, 2> m) : words_{m[0], m[1]} {}
-  friend constexpr bool operator==(per_note_pitch_bend const &a, per_note_pitch_bend const &b) = default;
+  constexpr per_note_pitch_bend() noexcept = default;
+  constexpr explicit per_note_pitch_bend(std::span<std::uint32_t, 2> m) noexcept : words_{m[0], m[1]} {}
+  friend constexpr bool operator==(per_note_pitch_bend const &, per_note_pitch_bend const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -1846,10 +1889,18 @@ struct per_note_pitch_bend {
   UMP_GETTER_SETTER(word0, note)
   UMP_GETTER_SETTER(word1, value)
 
+private:
+  friend struct ::std::tuple_size<per_note_pitch_bend>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1> words_;
 };
 
-}  // end namespace types::m2cvm
+UMP_TUPLE(m2cvm, per_note_pitch_bend)  // Define tuple_size and tuple_element for m2cvm/per_note_pitch_bend
+
+namespace midi2 {
 
 //*                       _                       *
 //*  _  _ _ __  _ __   __| |_ _ _ ___ __ _ _ __   *
@@ -1871,7 +1922,7 @@ struct endpoint_discovery {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::endpoint_discovery); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::endpoint_discovery); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -1896,9 +1947,9 @@ struct endpoint_discovery {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr endpoint_discovery() = default;
-  constexpr explicit endpoint_discovery(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(endpoint_discovery const &lhs, endpoint_discovery const &rhs) = default;
+  constexpr endpoint_discovery() noexcept = default;
+  constexpr explicit endpoint_discovery(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(endpoint_discovery const &, endpoint_discovery const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -1917,7 +1968,7 @@ struct endpoint_info_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::endpoint_info_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::endpoint_info_notification); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -1948,9 +1999,11 @@ struct endpoint_info_notification {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr endpoint_info_notification() = default;
-  constexpr explicit endpoint_info_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(endpoint_info_notification const &, endpoint_info_notification const &) = default;
+  constexpr endpoint_info_notification() noexcept = default;
+  constexpr explicit endpoint_info_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(endpoint_info_notification const &,
+                                   endpoint_info_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -1974,7 +2027,7 @@ struct device_identity_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::device_identity_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::device_identity_notification); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2017,10 +2070,11 @@ struct device_identity_notification {
     using sw_revision_4 = details::bitfield<0, 7>;  // Software revision level byte 4
   };
 
-  constexpr device_identity_notification() = default;
-  constexpr explicit device_identity_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
+  constexpr device_identity_notification() noexcept = default;
+  constexpr explicit device_identity_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
   friend constexpr bool operator==(device_identity_notification const &,
-                                   device_identity_notification const &) = default;
+                                   device_identity_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2045,7 +2099,7 @@ struct endpoint_name_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::endpoint_name_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::endpoint_name_notification); }
 
     using mt = details::bitfield<28, 4>;  // 0x0F
     using format = details::bitfield<26, 2>;
@@ -2078,9 +2132,11 @@ struct endpoint_name_notification {
     using name14 = details::bitfield<0, 8>;
   };
 
-  constexpr endpoint_name_notification() = default;
-  constexpr explicit endpoint_name_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(endpoint_name_notification const &, endpoint_name_notification const &) = default;
+  constexpr endpoint_name_notification() noexcept = default;
+  constexpr explicit endpoint_name_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(endpoint_name_notification const &,
+                                   endpoint_name_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2108,7 +2164,7 @@ struct product_instance_id_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::product_instance_id_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::product_instance_id_notification); }
 
     using mt = details::bitfield<28, 4>;
     using format = details::bitfield<26, 2>;
@@ -2141,10 +2197,11 @@ struct product_instance_id_notification {
     using pid14 = details::bitfield<0, 8>;
   };
 
-  constexpr product_instance_id_notification() = default;
-  constexpr explicit product_instance_id_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
+  constexpr product_instance_id_notification() noexcept = default;
+  constexpr explicit product_instance_id_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
   friend constexpr bool operator==(product_instance_id_notification const &,
-                                   product_instance_id_notification const &) = default;
+                                   product_instance_id_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2174,7 +2231,7 @@ struct jr_configuration_request {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::jr_configuration_request); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::jr_configuration_request); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2200,9 +2257,11 @@ struct jr_configuration_request {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr jr_configuration_request() = default;
-  constexpr explicit jr_configuration_request(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(jr_configuration_request const &, jr_configuration_request const &) = default;
+  constexpr jr_configuration_request() noexcept = default;
+  constexpr explicit jr_configuration_request(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(jr_configuration_request const &,
+                                   jr_configuration_request const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2222,7 +2281,7 @@ struct jr_configuration_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::jr_configuration_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::jr_configuration_notification); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2248,10 +2307,11 @@ struct jr_configuration_notification {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr jr_configuration_notification() = default;
-  constexpr explicit jr_configuration_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
+  constexpr jr_configuration_notification() noexcept = default;
+  constexpr explicit jr_configuration_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
   friend constexpr bool operator==(jr_configuration_notification const &,
-                                   jr_configuration_notification const &) = default;
+                                   jr_configuration_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2271,7 +2331,7 @@ struct function_block_discovery {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::function_block_discovery); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::function_block_discovery); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2295,9 +2355,11 @@ struct function_block_discovery {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr function_block_discovery() = default;
-  constexpr explicit function_block_discovery(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(function_block_discovery const &, function_block_discovery const &) = default;
+  constexpr function_block_discovery() noexcept = default;
+  constexpr explicit function_block_discovery(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(function_block_discovery const &,
+                                   function_block_discovery const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2316,7 +2378,7 @@ struct function_block_info_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::function_block_info_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::function_block_info_notification); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2347,10 +2409,11 @@ struct function_block_info_notification {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr function_block_info_notification() = default;
-  constexpr explicit function_block_info_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
+  constexpr function_block_info_notification() noexcept = default;
+  constexpr explicit function_block_info_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
   friend constexpr bool operator==(function_block_info_notification const &,
-                                   function_block_info_notification const &) = default;
+                                   function_block_info_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2375,7 +2438,7 @@ struct function_block_name_notification {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::function_block_name_notification); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::function_block_name_notification); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2408,10 +2471,11 @@ struct function_block_name_notification {
     using name12 = details::bitfield<0, 8>;
   };
 
-  constexpr function_block_name_notification() = default;
-  constexpr explicit function_block_name_notification(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
+  constexpr function_block_name_notification() noexcept = default;
+  constexpr explicit function_block_name_notification(std::span<std::uint32_t, 4> m) noexcept
+      : words_{m[0], m[1], m[2], m[3]} {}
   friend constexpr bool operator==(function_block_name_notification const &,
-                                   function_block_name_notification const &) = default;
+                                   function_block_name_notification const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2439,7 +2503,7 @@ struct start_of_clip {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::start_of_clip); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::start_of_clip); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2462,9 +2526,9 @@ struct start_of_clip {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr start_of_clip() = default;
-  constexpr explicit start_of_clip(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(start_of_clip const &, start_of_clip const &) = default;
+  constexpr start_of_clip() noexcept = default;
+  constexpr explicit start_of_clip(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(start_of_clip const &, start_of_clip const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2481,7 +2545,7 @@ struct end_of_clip {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::ump_stream::end_of_clip); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::ump_stream::end_of_clip); }
 
     using mt = details::bitfield<28, 4>;       // 0x0F
     using format = details::bitfield<26, 2>;   // 0x00
@@ -2504,9 +2568,9 @@ struct end_of_clip {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr end_of_clip() = default;
-  constexpr explicit end_of_clip(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(end_of_clip const &, end_of_clip const &) = default;
+  constexpr end_of_clip() noexcept = default;
+  constexpr explicit end_of_clip(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(end_of_clip const &, end_of_clip const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, format)
@@ -2541,7 +2605,7 @@ struct set_tempo {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::flex_data::set_tempo); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::flex_data::set_tempo); }
 
     using mt = details::bitfield<28, 4>;  // 0x0D
     using group = details::bitfield<24, 4>;
@@ -2567,9 +2631,9 @@ struct set_tempo {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr set_tempo() = default;
-  constexpr explicit set_tempo(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(set_tempo const &, set_tempo const &) = default;
+  constexpr set_tempo() noexcept = default;
+  constexpr explicit set_tempo(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(set_tempo const &, set_tempo const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -2590,7 +2654,7 @@ struct set_time_signature {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::flex_data::set_time_signature); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::flex_data::set_time_signature); }
 
     using mt = details::bitfield<28, 4>;  // 0x0D
     using group = details::bitfield<24, 4>;
@@ -2620,9 +2684,9 @@ struct set_time_signature {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr set_time_signature() = default;
-  constexpr explicit set_time_signature(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(set_time_signature const &, set_time_signature const &) = default;
+  constexpr set_time_signature() noexcept = default;
+  constexpr explicit set_time_signature(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(set_time_signature const &, set_time_signature const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -2646,7 +2710,7 @@ struct set_metronome {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::flex_data::set_metronome); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::flex_data::set_metronome); }
 
     using mt = details::bitfield<28, 4>;  // 0x0D
     using group = details::bitfield<24, 4>;
@@ -2680,9 +2744,9 @@ struct set_metronome {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr set_metronome() = default;
-  constexpr explicit set_metronome(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(set_metronome const &, set_metronome const &) = default;
+  constexpr set_metronome() noexcept = default;
+  constexpr explicit set_metronome(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(set_metronome const &, set_metronome const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -2707,7 +2771,7 @@ struct set_key_signature {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::flex_data::set_key_signature); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::flex_data::set_key_signature); }
 
     using mt = details::bitfield<28, 4>;  // 0x0D
     using group = details::bitfield<24, 4>;
@@ -2735,9 +2799,9 @@ struct set_key_signature {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr set_key_signature() = default;
-  constexpr explicit set_key_signature(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(set_key_signature const &, set_key_signature const &) = default;
+  constexpr set_key_signature() noexcept = default;
+  constexpr explicit set_key_signature(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(set_key_signature const &, set_key_signature const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -2813,7 +2877,7 @@ struct set_chord_name {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(midi2::flex_data::set_chord_name); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::flex_data::set_chord_name); }
 
     using mt = details::bitfield<28, 4>;  // 0x0D
     using group = details::bitfield<24, 4>;
@@ -2858,9 +2922,9 @@ struct set_chord_name {
     using bass_alter_2_degree = details::bitfield<0, 4>;
   };
 
-  constexpr set_chord_name() = default;
-  constexpr explicit set_chord_name(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(set_chord_name const &, set_chord_name const &) = default;
+  constexpr set_chord_name() noexcept = default;
+  constexpr explicit set_chord_name(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(set_chord_name const &, set_chord_name const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -2896,7 +2960,7 @@ struct text_common {
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->set<mt>(to_underlying(ump_message_type::flex_data)); }
+    constexpr word0() noexcept { this->set<mt>(to_underlying(ump_message_type::flex_data)); }
 
     using mt = details::bitfield<28, 4>;  // 0x0D
     using group = details::bitfield<24, 4>;
@@ -2922,9 +2986,9 @@ struct text_common {
     using value3 = details::bitfield<0, 32>;
   };
 
-  constexpr text_common() = default;
-  constexpr explicit text_common(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(text_common const &, text_common const &) = default;
+  constexpr text_common() noexcept = default;
+  constexpr explicit text_common(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(text_common const &, text_common const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -2978,7 +3042,7 @@ template <midi2::data128 Status> struct sysex8 {
   class word0 : public types::details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(Status); }
+    constexpr word0() noexcept { this->init<mt, status>(Status); }
 
     using mt = types::details::bitfield<28, 4>;  ///< Always 0x05
     using group = types::details::bitfield<24, 4>;
@@ -3015,9 +3079,9 @@ template <midi2::data128 Status> struct sysex8 {
     using data12 = types::details::bitfield<0, 8>;
   };
 
-  constexpr sysex8() = default;
-  constexpr explicit sysex8(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(sysex8 const &, sysex8 const &) = default;
+  constexpr sysex8() noexcept = default;
+  constexpr explicit sysex8(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(sysex8 const &, sysex8 const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER(word0, status)
@@ -3056,7 +3120,7 @@ struct mds_header {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(midi2::data128::mixed_data_set_header); }
+    constexpr word0() noexcept { this->init<mt, status>(midi2::data128::mixed_data_set_header); }
 
     using mt = types::details::bitfield<28, 4>;  ///< Always 0x05
     using group = types::details::bitfield<24, 4>;
@@ -3086,9 +3150,9 @@ struct mds_header {
     using sub_id_2 = types::details::bitfield<0, 16>;
   };
 
-  constexpr mds_header() = default;
-  constexpr explicit mds_header(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(mds_header const &, mds_header const &) = default;
+  constexpr mds_header() noexcept = default;
+  constexpr explicit mds_header(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(mds_header const &, mds_header const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -3109,7 +3173,7 @@ struct mds_payload {
   class word0 : public ::midi2::types::details::word_base {
   public:
     using word_base::word_base;
-    constexpr word0() { this->init<mt, status>(::midi2::data128::mixed_data_set_payload); }
+    constexpr word0() noexcept { this->init<mt, status>(::midi2::data128::mixed_data_set_payload); }
 
     using mt = ::midi2::types::details::bitfield<28, 4>;  ///< Always 0x05
     using group = ::midi2::types::details::bitfield<24, 4>;
@@ -3133,9 +3197,9 @@ struct mds_payload {
     using value3 = ::midi2::types::details::bitfield<0, 32>;
   };
 
-  constexpr mds_payload() = default;
-  constexpr explicit mds_payload(std::span<std::uint32_t, 4> m) : words_{m[0], m[1], m[2], m[3]} {}
-  friend constexpr bool operator==(mds_payload const &, mds_payload const &) = default;
+  constexpr mds_payload() noexcept = default;
+  constexpr explicit mds_payload(std::span<std::uint32_t, 4> m) noexcept : words_{m[0], m[1], m[2], m[3]} {}
+  friend constexpr bool operator==(mds_payload const &, mds_payload const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
@@ -3163,52 +3227,6 @@ template <> struct message_size<ump_message_type::reserved128_0E> : std::integra
 }  // end namespace midi2
 
 namespace std {
-
-template <>
-struct tuple_size<midi2::types::m2cvm::program_change>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::program_change::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::channel_pressure>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::channel_pressure::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::rpn_controller>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::rpn_controller::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::nrpn_controller>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::nrpn_controller::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::nrpn_per_note_controller>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::nrpn_per_note_controller::words_)>::value> {
-};
-template <>
-struct tuple_size<midi2::types::m2cvm::rpn_relative_controller>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::rpn_relative_controller::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::nrpn_relative_controller>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::nrpn_relative_controller::words_)>::value> {
-};
-template <>
-struct tuple_size<midi2::types::m2cvm::per_note_management>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::per_note_management::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::control_change>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::control_change::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::pitch_bend>
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m2cvm::pitch_bend::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::m2cvm::per_note_pitch_bend>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::per_note_pitch_bend::words_)>::value> {};
 
 template <>
 struct tuple_size<midi2::types::ump_stream::endpoint_discovery>

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -1900,15 +1900,14 @@ private:
 
 UMP_TUPLE(m2cvm, per_note_pitch_bend)  // Define tuple_size and tuple_element for m2cvm/per_note_pitch_bend
 
-namespace midi2 {
-
 //*                       _                       *
 //*  _  _ _ __  _ __   __| |_ _ _ ___ __ _ _ __   *
 //* | || | '  \| '_ \ (_-<  _| '_/ -_) _` | '  \  *
 //*  \_,_|_|_|_| .__/ /__/\__|_| \___\__,_|_|_|_| *
 //*            |_|                                *
-template <> struct message_size<ump_message_type::ump_stream> : std::integral_constant<unsigned, 4> {};
-namespace types::ump_stream {
+template <> struct midi2::message_size<midi2::ump_message_type::ump_stream> : std::integral_constant<unsigned, 4> {};
+
+namespace midi2::types::ump_stream {
 
 template <std::size_t I, typename T> auto const &get(T const &t) noexcept {
   return get<I>(t.words_);
@@ -1917,8 +1916,24 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
   return get<I>(t.words_);
 }
 
+class endpoint_discovery;
+class endpoint_info_notification;
+class device_identity_notification;
+class endpoint_name_notification;
+class product_instance_id_notification;
+class jr_configuration_request;
+class jr_configuration_notification;
+class function_block_discovery;
+class function_block_info_notification;
+class function_block_name_notification;
+class start_of_clip;
+class end_of_clip;
+
+}  // namespace midi2::types::ump_stream
+
 // 7.1.1 Endpoint Discovery Message
-struct endpoint_discovery {
+class midi2::types::ump_stream::endpoint_discovery {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -1960,11 +1975,20 @@ struct endpoint_discovery {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<endpoint_discovery>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+UMP_TUPLE(ump_stream, endpoint_discovery)  // Define tuple_size and tuple_element for ump_stream/endpoint_discovery
+
 // 7.1.2 Endpoint Info Notification Message
-struct endpoint_info_notification {
+class midi2::types::ump_stream::endpoint_info_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2019,11 +2043,21 @@ struct endpoint_info_notification {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<endpoint_info_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/endpoint_info_notification
+UMP_TUPLE(ump_stream, endpoint_info_notification)
+
 // 7.1.3 Device Identity Notification Message
-struct device_identity_notification {
+class midi2::types::ump_stream::device_identity_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2091,11 +2125,21 @@ struct device_identity_notification {
   UMP_GETTER_SETTER(word3, sw_revision_3)
   UMP_GETTER_SETTER(word3, sw_revision_4)
 
+private:
+  friend struct ::std::tuple_size<device_identity_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/device_identity_notification
+UMP_TUPLE(ump_stream, device_identity_notification)
+
 // 7.1.4 Endpoint Name Notification
-struct endpoint_name_notification {
+class midi2::types::ump_stream::endpoint_name_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2156,11 +2200,21 @@ struct endpoint_name_notification {
   UMP_GETTER_SETTER(word3, name13)
   UMP_GETTER_SETTER(word3, name14)
 
+private:
+  friend struct ::std::tuple_size<endpoint_name_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/endpoint_name_notification
+UMP_TUPLE(ump_stream, endpoint_name_notification)
+
 // 7.1.5 Product Instance Id Notification Message
-struct product_instance_id_notification {
+class midi2::types::ump_stream::product_instance_id_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2221,13 +2275,23 @@ struct product_instance_id_notification {
   UMP_GETTER_SETTER(word3, pid13)
   UMP_GETTER_SETTER(word3, pid14)
 
+private:
+  friend struct ::std::tuple_size<product_instance_id_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
+
+// Define tuple_size and tuple_element for ump_stream/product_instance_id_notification
+UMP_TUPLE(ump_stream, product_instance_id_notification)
 
 // 7.1.6 Selecting a MIDI Protocol and Jitter Reduction Timestamps for a UMP Stream
 // 7.1.6.1 Steps to Select Protocol and Jitter Reduction Timestamps
 // 7.1.6.2 JR Stream Configuration Request
-struct jr_configuration_request {
+class midi2::types::ump_stream::jr_configuration_request {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2273,11 +2337,21 @@ struct jr_configuration_request {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<jr_configuration_request>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/jr_configuration_request
+UMP_TUPLE(ump_stream, jr_configuration_request)
+
 // 7.1.6.3 JR Stream Configuration Notification Message
-struct jr_configuration_notification {
+class midi2::types::ump_stream::jr_configuration_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2323,11 +2397,21 @@ struct jr_configuration_notification {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<jr_configuration_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/jr_configuration_notification
+UMP_TUPLE(ump_stream, jr_configuration_notification)
+
 // 7.1.7 Function Block Discovery Message
-struct function_block_discovery {
+class midi2::types::ump_stream::function_block_discovery {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2370,11 +2454,21 @@ struct function_block_discovery {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<function_block_discovery>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/function_block_discovery
+UMP_TUPLE(ump_stream, function_block_discovery)
+
 // 7.1.8 Function Block Info Notification
-struct function_block_info_notification {
+class midi2::types::ump_stream::function_block_info_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2430,11 +2524,21 @@ struct function_block_info_notification {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<function_block_info_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/function_block_info_notification
+UMP_TUPLE(ump_stream, function_block_info_notification)
+
 // 7.1.9 Function Block Name Notification
-struct function_block_name_notification {
+class midi2::types::ump_stream::function_block_name_notification {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2495,11 +2599,21 @@ struct function_block_name_notification {
   UMP_GETTER_SETTER(word3, name11)
   UMP_GETTER_SETTER(word3, name12)
 
+private:
+  friend struct ::std::tuple_size<function_block_name_notification>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+// Define tuple_size and tuple_element for ump_stream/function_block_name_notification
+UMP_TUPLE(ump_stream, function_block_name_notification)
+
 // 7.1.10 Start of Clip Message
-struct start_of_clip {
+class midi2::types::ump_stream::start_of_clip {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2537,11 +2651,20 @@ struct start_of_clip {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<start_of_clip>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+UMP_TUPLE(ump_stream, start_of_clip)  // Define tuple_size and tuple_element for ump_stream/start_of_clip
+
 // 7.1.11 End of Clip Message
-struct end_of_clip {
+class midi2::types::ump_stream::end_of_clip {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2579,10 +2702,19 @@ struct end_of_clip {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<end_of_clip>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-};  // end namespace types::ump_stream
+UMP_TUPLE(ump_stream, end_of_clip)  // Define tuple_size and tuple_element for ump_stream/end_of_clip
+
+namespace midi2 {
+namespace types::ump_stream {};  // end namespace types::ump_stream
 
 //*   __ _              _      _         *
 //*  / _| |_____ __  __| |__ _| |_ __ _  *
@@ -3227,60 +3359,6 @@ template <> struct message_size<ump_message_type::reserved128_0E> : std::integra
 }  // end namespace midi2
 
 namespace std {
-
-template <>
-struct tuple_size<midi2::types::ump_stream::endpoint_discovery>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::ump_stream::endpoint_discovery::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::endpoint_info_notification>
-    : std::integral_constant<
-          std::size_t, std::tuple_size_v<decltype(midi2::types::ump_stream::endpoint_info_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::device_identity_notification>
-    : std::integral_constant<
-          std::size_t, std::tuple_size_v<decltype(midi2::types::ump_stream::device_identity_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::endpoint_name_notification>
-    : std::integral_constant<
-          std::size_t, std::tuple_size_v<decltype(midi2::types::ump_stream::endpoint_name_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::product_instance_id_notification>
-    : std::integral_constant<
-          std::size_t,
-          std::tuple_size_v<decltype(midi2::types::ump_stream::product_instance_id_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::jr_configuration_request>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::ump_stream::jr_configuration_request::words_)>> {
-};
-template <>
-struct tuple_size<midi2::types::ump_stream::jr_configuration_notification>
-    : std::integral_constant<
-          std::size_t, std::tuple_size_v<decltype(midi2::types::ump_stream::jr_configuration_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::function_block_discovery>
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::ump_stream::function_block_discovery::words_)>> {
-};
-template <>
-struct tuple_size<midi2::types::ump_stream::function_block_info_notification>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<
-          std::size_t,
-          std::tuple_size_v<decltype(midi2::types::ump_stream::function_block_info_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::function_block_name_notification>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<
-          std::size_t,
-          std::tuple_size_v<decltype(midi2::types::ump_stream::function_block_name_notification::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::start_of_clip>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::ump_stream::start_of_clip::words_)>> {};
-template <>
-struct tuple_size<midi2::types::ump_stream::end_of_clip>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::ump_stream::end_of_clip::words_)>> {
-};
 
 // NOLINTNEXTLINE(cert-dcl58-cpp]
 template <midi2::data128 Status>

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -197,7 +197,7 @@ private:
 /// Provides access to the number of words in a noop message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::utility::noop>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::utility::noop::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::utility::noop::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the noop message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::noop> {  // NOLINT(cert-dcl58-cpp]
@@ -243,7 +243,7 @@ private:
 /// Provides access to the number of words in a jr_clock message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::utility::jr_clock>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::utility::jr_clock::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::utility::jr_clock::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the jr_clock message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::jr_clock> {  // NOLINT(cert-dcl58-cpp]
@@ -289,8 +289,7 @@ private:
 /// Provides access to the number of words in a jr_timestamp message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::utility::jr_timestamp>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::utility::jr_timestamp::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::utility::jr_timestamp::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the jr_timestamp message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::utility::jr_timestamp> {  // NOLINT(cert-dcl58-cpp]
@@ -337,7 +336,7 @@ private:
 template <>
 struct std::tuple_size<midi2::types::utility::delta_clockstamp_tpqn>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::utility::delta_clockstamp_tpqn::words_)>::value> {};
+                             std::tuple_size_v<decltype(midi2::types::utility::delta_clockstamp_tpqn::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the delta_clockstamp_tpqn message.
 template <std::size_t I>
@@ -384,7 +383,7 @@ private:
 template <>
 struct std::tuple_size<midi2::types::utility::delta_clockstamp>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::utility::delta_clockstamp::words_)>::value> {};
+                             std::tuple_size_v<decltype(midi2::types::utility::delta_clockstamp::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the delta_clockstamp message.
 template <std::size_t I>
@@ -415,6 +414,8 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
 
 class midi_time_code;
 class song_position_pointer;
+class song_select;
+class tune_request;
 
 }  // namespace midi2::types::system
 
@@ -456,8 +457,7 @@ private:
 /// Provides access to the number of words in a midi_time_code message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::system::midi_time_code>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::midi_time_code::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::system::midi_time_code::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the midi_time_code message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::system::midi_time_code> {  // NOLINT(cert-dcl58-cpp]
@@ -507,26 +507,24 @@ private:
 template <>
 struct std::tuple_size<midi2::types::system::song_position_pointer>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::song_position_pointer::words_)>::value> {};
+                             std::tuple_size_v<decltype(midi2::types::system::song_position_pointer::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of the song_position_pointer message.
 template <std::size_t I>
 struct std::tuple_element<I, midi2::types::system::song_position_pointer> {  // NOLINT(cert-dcl58-cpp]
-  using type = std::tuple_element_t<I, decltype(midi2::types::system::midi_time_code::words_)>;
+  using type = std::tuple_element_t<I, decltype(midi2::types::system::song_position_pointer::words_)>;
 };
 
 static_assert(std::tuple_size_v<midi2::types::system::song_position_pointer> ==
               midi2::message_size<midi2::ump_message_type::system>::value);
 
-namespace midi2 {
-namespace types::system {
-
-struct song_select {
+class midi2::types::system::song_select {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::song_select); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::song_select); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -537,24 +535,44 @@ struct song_select {
     using reserved2 = details::bitfield<0, 7>;
   };
 
-  constexpr song_select() = default;
-  constexpr explicit song_select(std::uint32_t const w0) : words_{w0} {}
-  friend constexpr bool operator==(song_select const &, song_select const &) = default;
+  constexpr song_select() noexcept = default;
+  constexpr explicit song_select(std::uint32_t const w0) noexcept : words_{w0} {}
+  friend constexpr bool operator==(song_select const &, song_select const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
   UMP_GETTER_SETTER(word0, song)
 
+private:
+  friend struct ::std::tuple_size<song_select>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
 
-struct tune_request {
+/// Provides access to the number of words in a song_select as a compile-time constant expression.
+template <>
+struct std::tuple_size<midi2::types::system::song_select>  // NOLINT(cert-dcl58-cpp]
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::system::song_select::words_)>> {};
+
+/// Provides compile-time indexed access to the types of the elements of the song_select message..
+template <std::size_t I> struct std::tuple_element<I, midi2::types::system::song_select> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element_t<I, decltype(midi2::types::system::song_select::words_)>;
+};
+
+static_assert(std::tuple_size_v<midi2::types::system::song_select> ==
+              midi2::message_size<midi2::ump_message_type::system>::value);
+
+class midi2::types::system::tune_request {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
 
-    constexpr word0() { this->init<mt, status>(system_crt::tune_request); }
+    constexpr word0() noexcept { this->init<mt, status>(system_crt::tune_request); }
 
     using mt = details::bitfield<28, 4>;  ///< Always 0x1
     using group = details::bitfield<24, 4>;
@@ -563,16 +581,38 @@ struct tune_request {
     using reserved1 = details::bitfield<0, 8>;
   };
 
-  constexpr tune_request() = default;
-  constexpr explicit tune_request(std::uint32_t const w0_) : words_{w0_} {}
-  friend constexpr bool operator==(tune_request const &, tune_request const &) = default;
+  constexpr tune_request() noexcept = default;
+  constexpr explicit tune_request(std::uint32_t const w0_) noexcept : words_{w0_} {}
+  friend constexpr bool operator==(tune_request const &, tune_request const &) noexcept = default;
 
   UMP_GETTER(word0, mt)
   UMP_GETTER_SETTER(word0, group)
   UMP_GETTER(word0, status)
 
+private:
+  friend struct ::std::tuple_size<tune_request>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0> words_;
 };
+
+/// Provides access to the number of words in a song_select as a tune_request constant expression.
+template <>
+struct std::tuple_size<midi2::types::system::tune_request>  // NOLINT(cert-dcl58-cpp]
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::system::tune_request::words_)>> {};
+
+/// Provides compile-time indexed access to the types of the elements of the tune_request message..
+template <std::size_t I> struct std::tuple_element<I, midi2::types::system::tune_request> {  // NOLINT(cert-dcl58-cpp]
+  using type = std::tuple_element_t<I, decltype(midi2::types::system::tune_request::words_)>;
+};
+
+static_assert(std::tuple_size_v<midi2::types::system::tune_request> ==
+              midi2::message_size<midi2::ump_message_type::system>::value);
+
+namespace midi2 {
+namespace types::system {
 
 struct timing_clock {
   class word0 : public details::word_base {
@@ -797,7 +837,7 @@ private:
 
 template <>
 struct std::tuple_size<midi2::types::m1cvm::note_on>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m1cvm::note_on::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m1cvm::note_on::words_)>> {};
 
 template <std::size_t I> struct std::tuple_element<I, midi2::types::m1cvm::note_on> {  // NOLINT(cert-dcl58-cpp]
   using type = std::tuple_element<I, decltype(midi2::types::m1cvm::note_on::words_)>::type;
@@ -847,7 +887,7 @@ private:
 
 template <>
 struct std::tuple_size<midi2::types::m1cvm::note_off>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m1cvm::note_off::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m1cvm::note_off::words_)>> {};
 
 template <std::size_t I> struct std::tuple_element<I, midi2::types::m1cvm::note_off> {  // NOLINT(cert-dcl58-cpp]
   using type = std::tuple_element<I, decltype(midi2::types::m1cvm::note_off::words_)>::type;
@@ -1188,7 +1228,7 @@ private:
 /// Provides access to the number of words in a MIDI 2 note-off message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::m2cvm::note_off>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m2cvm::note_off::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m2cvm::note_off::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of MIDI 2 note-off message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::note_off> {  // NOLINT(cert-dcl58-cpp]
@@ -1248,7 +1288,7 @@ private:
 /// Provides access to the number of words in a MIDI 2 note-on message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::m2cvm::note_on>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::m2cvm::note_on::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m2cvm::note_on::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of MIDI 2 note-on message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::note_on> {  // NOLINT(cert-dcl58-cpp]
@@ -1304,8 +1344,7 @@ private:
 /// Provides access to the number of words in a MIDI 2 poly-pressure message as a compile-time constant expression.
 template <>
 struct std::tuple_size<midi2::types::m2cvm::poly_pressure>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::poly_pressure::words_)>::value> {};
+    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::m2cvm::poly_pressure::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of MIDI 2 poly-pressure message.
 template <std::size_t I> struct std::tuple_element<I, midi2::types::m2cvm::poly_pressure> {  // NOLINT(cert-dcl58-cpp]
@@ -1363,7 +1402,7 @@ private:
 template <>
 struct std::tuple_size<midi2::types::m2cvm::rpn_per_note_controller>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>::value> {};
+                             std::tuple_size_v<decltype(midi2::types::m2cvm::rpn_per_note_controller::words_)>> {};
 
 /// Provides compile-time indexed access to the types of the elements of MIDI 2 poly-pressure message.
 template <std::size_t I>
@@ -3113,14 +3152,6 @@ template <> struct message_size<ump_message_type::reserved128_0E> : std::integra
 
 namespace std {
 
-template <>
-struct tuple_size<midi2::types::system::song_select>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size<decltype(midi2::types::system::song_select::words_)>::value> {
-};
-template <>
-struct tuple_size<midi2::types::system::tune_request>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::system::tune_request::words_)>::value> {};
 template <>
 struct tuple_size<midi2::types::system::timing_clock>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t,

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -2789,7 +2789,7 @@ private:
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-UMP_TUPLE(flex_data, set_tempo)  // Define tuple_size and tuple_element for ump_stream/set_tempo
+UMP_TUPLE(flex_data, set_tempo)  // Define tuple_size and tuple_element for flex_data/set_tempo
 
 // 7.5.4 Set Time Signature Message
 class midi2::types::flex_data::set_time_signature {
@@ -2853,7 +2853,7 @@ private:
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-UMP_TUPLE(flex_data, set_time_signature)  // Define tuple_size and tuple_element for ump_stream/set_time_signature
+UMP_TUPLE(flex_data, set_time_signature)  // Define tuple_size and tuple_element for flex_data/set_time_signature
 
 // 7.5.5 Set Metronome Message
 class midi2::types::flex_data::set_metronome {
@@ -2923,7 +2923,7 @@ private:
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-UMP_TUPLE(flex_data, set_metronome)  // Define tuple_size and tuple_element for ump_stream/set_metronome
+UMP_TUPLE(flex_data, set_metronome)  // Define tuple_size and tuple_element for flex_data/set_metronome
 
 // 7.5.7 Set Key Signature Message
 class midi2::types::flex_data::set_key_signature {
@@ -2984,7 +2984,7 @@ private:
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-UMP_TUPLE(flex_data, set_key_signature)  // Define tuple_size and tuple_element for ump_stream/set_key_signature
+UMP_TUPLE(flex_data, set_key_signature)  // Define tuple_size and tuple_element for flex_data/set_key_signature
 
 // 7.5.8 Set Chord Name Message
 namespace midi2::types::flex_data {
@@ -3134,7 +3134,7 @@ private:
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-UMP_TUPLE(flex_data, set_chord_name)  // Define tuple_size and tuple_element for ump_stream/set_chord_name
+UMP_TUPLE(flex_data, set_chord_name)  // Define tuple_size and tuple_element for flex_data/set_chord_name
 
 // 7.5.9 Text Messages Common Format
 class midi2::types::flex_data::text_common {
@@ -3192,10 +3192,7 @@ private:
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-UMP_TUPLE(flex_data, text_common)  // Define tuple_size and tuple_element for ump_stream/text_common
-
-namespace midi2 {
-namespace types::flex_data {}  // end namespace types::flex_data
+UMP_TUPLE(flex_data, text_common)  // Define tuple_size and tuple_element for flex_data/text_common
 
 //*     _      _          _ ___ ___  *
 //*  __| |__ _| |_ __ _  / |_  | _ ) *
@@ -3203,9 +3200,9 @@ namespace types::flex_data {}  // end namespace types::flex_data
 //* \__,_\__,_|\__\__,_| |_/___\___/ *
 //*                                  *
 
-template <> struct message_size<ump_message_type::data128> : std::integral_constant<unsigned, 4> {};
+template <> struct midi2::message_size<midi2::ump_message_type::data128> : std::integral_constant<unsigned, 4> {};
 
-namespace types::data128 {
+namespace midi2::types::data128 {
 
 template <std::size_t I, typename T> auto const &get(T const &t) noexcept {
   return get<I>(t.words_);
@@ -3214,13 +3211,14 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
   return get<I>(t.words_);
 }
 
-// 7.8 System Exclusive 8 (8-Bit) Messages
+namespace details {
 
+// 7.8 System Exclusive 8 (8-Bit) Messages
 // SysEx8 in 1 UMP (word 1)
 // SysEx8 Start (word 1)
 // SysEx8 Continue (word 1)
 // SysEx8 End (word 1)
-namespace details {
+template <::midi2::data128 Status> class sysex8;
 
 template <std::size_t I, typename T> auto const &get(T const &t) noexcept {
   return get<I>(t.words_);
@@ -3229,45 +3227,53 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
   return get<I>(t.words_);
 }
 
-template <midi2::data128 Status> struct sysex8 {
-  class word0 : public types::details::word_base {
+}  // end namespace details
+
+class mds_header;
+class mds_payload;
+
+}  // namespace midi2::types::data128
+
+template <midi2::data128 Status> class midi2::types::data128::details::sysex8 {
+public:
+  class word0 : public midi2::types::details::word_base {
   public:
     using word_base::word_base;
     constexpr word0() noexcept { this->init<mt, status>(Status); }
 
-    using mt = types::details::bitfield<28, 4>;  ///< Always 0x05
-    using group = types::details::bitfield<24, 4>;
-    using status = types::details::bitfield<20, 4>;
-    using number_of_bytes = types::details::bitfield<16, 4>;
-    using stream_id = types::details::bitfield<8, 8>;
-    using data0 = types::details::bitfield<0, 8>;
+    using mt = midi2::types::details::bitfield<28, 4>;  ///< Always 0x05
+    using group = midi2::types::details::bitfield<24, 4>;
+    using status = midi2::types::details::bitfield<20, 4>;
+    using number_of_bytes = midi2::types::details::bitfield<16, 4>;
+    using stream_id = midi2::types::details::bitfield<8, 8>;
+    using data0 = midi2::types::details::bitfield<0, 8>;
   };
-  class word1 : public types::details::word_base {
+  class word1 : public midi2::types::details::word_base {
   public:
     using word_base::word_base;
 
-    using data1 = types::details::bitfield<24, 8>;
-    using data2 = types::details::bitfield<16, 8>;
-    using data3 = types::details::bitfield<8, 8>;
-    using data4 = types::details::bitfield<0, 8>;
+    using data1 = midi2::types::details::bitfield<24, 8>;
+    using data2 = midi2::types::details::bitfield<16, 8>;
+    using data3 = midi2::types::details::bitfield<8, 8>;
+    using data4 = midi2::types::details::bitfield<0, 8>;
   };
-  class word2 : public types::details::word_base {
+  class word2 : public midi2::types::details::word_base {
   public:
     using word_base::word_base;
 
-    using data5 = types::details::bitfield<24, 8>;
-    using data6 = types::details::bitfield<16, 8>;
-    using data7 = types::details::bitfield<8, 8>;
-    using data8 = types::details::bitfield<0, 8>;
+    using data5 = midi2::types::details::bitfield<24, 8>;
+    using data6 = midi2::types::details::bitfield<16, 8>;
+    using data7 = midi2::types::details::bitfield<8, 8>;
+    using data8 = midi2::types::details::bitfield<0, 8>;
   };
-  class word3 : public types::details::word_base {
+  class word3 : public midi2::types::details::word_base {
   public:
     using word_base::word_base;
 
-    using data9 = types::details::bitfield<24, 8>;
-    using data10 = types::details::bitfield<16, 8>;
-    using data11 = types::details::bitfield<8, 8>;
-    using data12 = types::details::bitfield<0, 8>;
+    using data9 = midi2::types::details::bitfield<24, 8>;
+    using data10 = midi2::types::details::bitfield<16, 8>;
+    using data11 = midi2::types::details::bitfield<8, 8>;
+    using data12 = midi2::types::details::bitfield<0, 8>;
   };
 
   constexpr sysex8() noexcept = default;
@@ -3293,20 +3299,39 @@ template <midi2::data128 Status> struct sysex8 {
   UMP_GETTER_SETTER(word3, data11)
   UMP_GETTER_SETTER(word3, data12)
 
-  std::tuple<word0, word1, word2, word3> words_;
+private:
+  friend struct ::std::tuple_size<sysex8>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
+  std::tuple<word0, word1, word2, word3> words_{};
 };
 
-}  // end namespace details
+template <::midi2::data128 Status>
+struct std::tuple_size<midi2::types::data128::details::sysex8<Status>> /* NOLINT(cert-dcl58-cpp]*/
+    : std::integral_constant<std::size_t,
+                             std::tuple_size_v<decltype(midi2::types::data128::details::sysex8<Status>::words_)>> {};
+
+template <std::size_t I, midi2::data128 Status>
+struct std::tuple_element<I, midi2::types::data128::details::sysex8<Status>> { /* NOLINT(cert-dcl58-cpp] */
+  using type = std::tuple_element_t<I, decltype(midi2::types::data128::details::sysex8<Status>::words_)>;
+};
+
+namespace midi2::types::data128 {
 
 using sysex8_in_1 = details::sysex8<midi2::data128::sysex8_in_1>;
 using sysex8_start = details::sysex8<midi2::data128::sysex8_start>;
 using sysex8_continue = details::sysex8<midi2::data128::sysex8_continue>;
 using sysex8_end = details::sysex8<midi2::data128::sysex8_end>;
 
+}  // end namespace midi2::types::data128
+
 // 7.9 Mixed Data Set Message
 // Mixed Data Set Header (word 1)
 // Mixed Data Set Payload (word 1)
-struct mds_header {
+class midi2::types::data128::mds_header {
+public:
   class word0 : public types::details::word_base {
   public:
     using word_base::word_base;
@@ -3357,10 +3382,19 @@ struct mds_header {
   UMP_GETTER_SETTER(word3, sub_id_1)
   UMP_GETTER_SETTER(word3, sub_id_2)
 
+private:
+  friend struct ::std::tuple_size<mds_header>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-struct mds_payload {
+UMP_TUPLE(data128, mds_header)  // Define tuple_size and tuple_element for data128/mds_header
+
+class midi2::types::data128::mds_payload {
+public:
   class word0 : public ::midi2::types::details::word_base {
   public:
     using word_base::word_base;
@@ -3401,37 +3435,25 @@ struct mds_payload {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<mds_payload>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-}  // end namespace types::data128
+UMP_TUPLE(data128, mds_payload)  // Define tuple_size and tuple_element for data128/mds_payload
 
-template <> struct message_size<ump_message_type::reserved32_06> : std::integral_constant<unsigned, 1> {};
-template <> struct message_size<ump_message_type::reserved32_07> : std::integral_constant<unsigned, 1> {};
-template <> struct message_size<ump_message_type::reserved64_08> : std::integral_constant<unsigned, 2> {};
-template <> struct message_size<ump_message_type::reserved64_09> : std::integral_constant<unsigned, 2> {};
-template <> struct message_size<ump_message_type::reserved64_0A> : std::integral_constant<unsigned, 2> {};
-template <> struct message_size<ump_message_type::reserved96_0B> : std::integral_constant<unsigned, 3> {};
-template <> struct message_size<ump_message_type::reserved96_0C> : std::integral_constant<unsigned, 3> {};
-template <> struct message_size<ump_message_type::reserved128_0E> : std::integral_constant<unsigned, 4> {};
-
-}  // end namespace midi2
-
-namespace std {
-
-// NOLINTNEXTLINE(cert-dcl58-cpp]
-template <midi2::data128 Status>
-struct tuple_size<midi2::types::data128::details::sysex8<Status>>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size_v<decltype(midi2::types::data128::details::sysex8<Status>::words_)>> {};
-template <>
-struct tuple_size<midi2::types::data128::mds_header>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::data128::mds_header::words_)>> {};
-template <>
-struct tuple_size<midi2::types::data128::mds_payload>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::data128::mds_payload::words_)>> {};
-
-}  // end namespace std
+template <> struct midi2::message_size<midi2::ump_message_type::reserved32_06> : std::integral_constant<unsigned, 1> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved32_07> : std::integral_constant<unsigned, 1> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved64_08> : std::integral_constant<unsigned, 2> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved64_09> : std::integral_constant<unsigned, 2> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved64_0A> : std::integral_constant<unsigned, 2> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved96_0B> : std::integral_constant<unsigned, 3> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved96_0C> : std::integral_constant<unsigned, 3> {};
+template <> struct midi2::message_size<midi2::ump_message_type::reserved128_0E> : std::integral_constant<unsigned, 4> {};
 
 #undef UMP_GETTER
 #undef UMP_SETTER

--- a/include/midi2/ump_types.hpp
+++ b/include/midi2/ump_types.hpp
@@ -731,8 +731,6 @@ private:
 
 UMP_TUPLE(system, reset)  // Define tuple_size and tuple_element for reset
 
-namespace midi2 {
-
 //*        _                 *
 //*  _ __ / |  ____ ___ __   *
 //* | '  \| | / _\ V / '  \  *
@@ -741,9 +739,9 @@ namespace midi2 {
 // F.1.3 Mess Type 0x2: MIDI 1.0 Channel Voice Messages
 // Table 28 4-Byte UMP Formats for Message Type 0x2: MIDI 1.0 Channel Voice
 // Messages
-template <> struct message_size<ump_message_type::m1cvm> : std::integral_constant<unsigned, 1> {};
+template <> struct midi2::message_size<midi2::ump_message_type::m1cvm> : std::integral_constant<unsigned, 1> {};
 
-namespace types::m1cvm {
+namespace midi2::types::m1cvm {
 
 template <std::size_t I, typename T> auto const &get(T const &t) noexcept {
   return get<I>(t.words_);
@@ -760,8 +758,7 @@ class program_change;
 class channel_pressure;
 class pitch_bend;
 
-}  // end namespace types::m1cvm
-}  // end namespace midi2
+}  // end namespace midi2::types::m1cvm
 
 // 7.3.2 MIDI 1.0 Note On Message
 class midi2::types::m1cvm::note_on {
@@ -1051,11 +1048,9 @@ UMP_TUPLE(m1cvm, pitch_bend)  // Define tuple_size and tuple_element for m1cvm/p
 //* \__,_\__,_|\__\__,_\___/ |_|  *
 //*                               *
 
-namespace midi2 {
+template <> struct midi2::message_size<midi2::ump_message_type::data64> : std::integral_constant<unsigned, 2> {};
 
-template <> struct message_size<ump_message_type::data64> : std::integral_constant<unsigned, 2> {};
-
-namespace types::data64::details {
+namespace midi2::types::data64::details {
 
 // 7.7 System Exclusive (7-Bit) Messages
 template <midi2::data64 Status> class sysex7;
@@ -1067,8 +1062,7 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
   return get<I>(t.words_);
 }
 
-}  // end namespace types::data64::details
-}  // end namespace midi2
+}  // end namespace midi2::types::data64::details
 
 template <midi2::data64 Status> class midi2::types::data64::details::sysex7 {
 public:
@@ -2713,17 +2707,15 @@ private:
 
 UMP_TUPLE(ump_stream, end_of_clip)  // Define tuple_size and tuple_element for ump_stream/end_of_clip
 
-namespace midi2 {
-namespace types::ump_stream {};  // end namespace types::ump_stream
-
 //*   __ _              _      _         *
 //*  / _| |_____ __  __| |__ _| |_ __ _  *
 //* |  _| / -_) \ / / _` / _` |  _/ _` | *
 //* |_| |_\___/_\_\ \__,_\__,_|\__\__,_| *
 //*                                      *
-template <> struct message_size<ump_message_type::flex_data> : std::integral_constant<unsigned, 4> {};
 
-namespace types::flex_data {
+template <> struct midi2::message_size<midi2::ump_message_type::flex_data> : std::integral_constant<unsigned, 4> {};
+
+namespace midi2::types::flex_data {
 
 template <std::size_t I, typename T> auto const &get(T const &t) noexcept {
   return get<I>(t.words_);
@@ -2732,8 +2724,18 @@ template <std::size_t I, typename T> auto &get(T &t) noexcept {
   return get<I>(t.words_);
 }
 
+class set_tempo;
+class set_time_signature;
+class set_metronome;
+class set_key_signature;
+class set_chord_name;
+class text_common;
+
+}  // namespace midi2::types::flex_data
+
 // 7.5.3 Set Tempo Message
-struct set_tempo {
+class midi2::types::flex_data::set_tempo {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2778,11 +2780,20 @@ struct set_tempo {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<set_tempo>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+UMP_TUPLE(flex_data, set_tempo)  // Define tuple_size and tuple_element for ump_stream/set_tempo
+
 // 7.5.4 Set Time Signature Message
-struct set_time_signature {
+class midi2::types::flex_data::set_time_signature {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2833,12 +2844,20 @@ struct set_time_signature {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<set_time_signature>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-// 7.5.5 Set Metronome Message
+UMP_TUPLE(flex_data, set_time_signature)  // Define tuple_size and tuple_element for ump_stream/set_time_signature
 
-struct set_metronome {
+// 7.5.5 Set Metronome Message
+class midi2::types::flex_data::set_metronome {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2895,11 +2914,20 @@ struct set_metronome {
   UMP_GETTER_SETTER(word2, num_subdivision_clicks_2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<set_metronome>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+UMP_TUPLE(flex_data, set_metronome)  // Define tuple_size and tuple_element for ump_stream/set_metronome
+
 // 7.5.7 Set Key Signature Message
-struct set_key_signature {
+class midi2::types::flex_data::set_key_signature {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -2947,10 +2975,20 @@ struct set_key_signature {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<set_key_signature>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+UMP_TUPLE(flex_data, set_key_signature)  // Define tuple_size and tuple_element for ump_stream/set_key_signature
+
 // 7.5.8 Set Chord Name Message
+namespace midi2::types::flex_data {
+
 enum class sharps_flats : std::int8_t {
   double_sharp = 2,
   sharp = 1,
@@ -3005,7 +3043,10 @@ enum class chord_type : std::uint8_t {
   seven_suspended_4th = 0x1B,
 };
 
-struct set_chord_name {
+}  // end namespace midi2::types::flex_data
+
+class midi2::types::flex_data::set_chord_name {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -3084,11 +3125,20 @@ struct set_chord_name {
   UMP_GETTER_SETTER(word3, bass_alter_2_type)
   UMP_GETTER_SETTER(word3, bass_alter_2_degree)
 
+private:
+  friend struct ::std::tuple_size<set_chord_name>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
+UMP_TUPLE(flex_data, set_chord_name)  // Define tuple_size and tuple_element for ump_stream/set_chord_name
+
 // 7.5.9 Text Messages Common Format
-struct text_common {
+class midi2::types::flex_data::text_common {
+public:
   class word0 : public details::word_base {
   public:
     using word_base::word_base;
@@ -3133,10 +3183,19 @@ struct text_common {
   UMP_GETTER_SETTER(word2, value2)
   UMP_GETTER_SETTER(word3, value3)
 
+private:
+  friend struct ::std::tuple_size<text_common>;
+  template <std::size_t I, typename T> friend struct ::std::tuple_element;
+  template <std::size_t I, typename T> friend auto const &get(T const &) noexcept;
+  template <std::size_t I, typename T> friend auto &get(T &) noexcept;
+
   std::tuple<word0, word1, word2, word3> words_;
 };
 
-}  // end namespace types::flex_data
+UMP_TUPLE(flex_data, text_common)  // Define tuple_size and tuple_element for ump_stream/text_common
+
+namespace midi2 {
+namespace types::flex_data {}  // end namespace types::flex_data
 
 //*     _      _          _ ___ ___  *
 //*  __| |__ _| |_ __ _  / |_  | _ ) *
@@ -3371,31 +3430,6 @@ struct tuple_size<midi2::types::data128::mds_header>  // NOLINT(cert-dcl58-cpp]
 template <>
 struct tuple_size<midi2::types::data128::mds_payload>  // NOLINT(cert-dcl58-cpp]
     : std::integral_constant<std::size_t, std::tuple_size_v<decltype(midi2::types::data128::mds_payload::words_)>> {};
-
-template <>
-struct tuple_size<midi2::types::flex_data::set_chord_name>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::flex_data::set_chord_name::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::flex_data::set_key_signature>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::flex_data::set_key_signature::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::flex_data::set_metronome>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::flex_data::set_metronome::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::flex_data::set_time_signature>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::flex_data::set_time_signature::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::flex_data::set_tempo>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::flex_data::set_tempo::words_)>::value> {};
-template <>
-struct tuple_size<midi2::types::flex_data::text_common>  // NOLINT(cert-dcl58-cpp]
-    : std::integral_constant<std::size_t,
-                             std::tuple_size<decltype(midi2::types::flex_data::text_common::words_)>::value> {};
 
 }  // end namespace std
 

--- a/src/ump_to_midi1.cpp
+++ b/src/ump_to_midi1.cpp
@@ -26,7 +26,7 @@ void ump_to_midi1::to_midi1_config::m2cvm::note_off(context_type *const ctxt, ty
                        .channel(in.channel())
                        .note(in.note())
                        .velocity(mcm_scale<m2v, m1v>(in.velocity()));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // note on
@@ -39,7 +39,7 @@ void ump_to_midi1::to_midi1_config::m2cvm::note_on(context_type *const ctxt, typ
                        .channel(in.channel())
                        .note(in.note())
                        .velocity(mcm_scale<m2v, m1v>(in.velocity()));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // poly pressure
@@ -54,7 +54,7 @@ void ump_to_midi1::to_midi1_config::m2cvm::poly_pressure(context_type *const ctx
                        .channel(in.channel())
                        .note(in.note())
                        .pressure(mcm_scale<m2v, m1v>(in.pressure()));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // program change
@@ -66,22 +66,19 @@ void ump_to_midi1::to_midi1_config::m2cvm::program_change(context_type *const ct
   if (in.bank_valid()) {
     // Control Change numbers 00H and 20H are defined as the Bank Select message. 00H is the MSB and
     // 20H is the LSB for a total of 14 bits. This allows 16,384 banks to be specified.
-    auto const cc = types::m1cvm::control_change{}
-                        .group(group)
-                        .channel(channel)
-                        .controller(control::bank_select)
-                        .value(in.bank_msb());
-    ctxt->push(cc.w);
+    ctxt->push(types::m1cvm::control_change{}
+                   .group(group)
+                   .channel(channel)
+                   .controller(control::bank_select)
+                   .value(in.bank_msb()));
 
-    auto const cc2 = types::m1cvm::control_change{}
-                         .group(group)
-                         .channel(channel)
-                         .controller(control::bank_select_lsb)
-                         .value(in.bank_lsb());
-    ctxt->push(cc2.w);
+    ctxt->push(types::m1cvm::control_change{}
+                   .group(group)
+                   .channel(channel)
+                   .controller(control::bank_select_lsb)
+                   .value(in.bank_lsb()));
   }
-  auto const out = types::m1cvm::program_change{}.group(group).channel(channel).program(in.program());
-  ctxt->push(out.w);
+  ctxt->push(types::m1cvm::program_change{}.group(group).channel(channel).program(in.program()));
 }
 
 // channel pressure
@@ -93,7 +90,7 @@ void ump_to_midi1::to_midi1_config::m2cvm::channel_pressure(context_type *const 
 
   const auto out =
       types::m1cvm::channel_pressure{}.group(in.group()).channel(in.channel()).data(mcm_scale<m2p, m1p>(in.value()));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // rpn controller
@@ -125,11 +122,11 @@ void ump_to_midi1::to_midi1_config::m2cvm::pn_message(context_type *const ctxt, 
     // Controller number MSB
     cc.controller(key.is_rpn ? control::rpn_msb : control::nrpn_msb);  // 0x65/0x63
     cc.value(controller_number.first);
-    ctxt->push(cc.w);
+    ctxt->push(cc);
     // Controller number LSB
     cc.controller(key.is_rpn ? control::rpn_lsb : control::nrpn_lsb);  // 0x64/0x62
     cc.value(controller_number.second);
-    ctxt->push(cc.w);
+    ctxt->push(cc);
   }
 
   auto const scaled_value = mcm_scale<32, 14>(value);
@@ -137,12 +134,12 @@ void ump_to_midi1::to_midi1_config::m2cvm::pn_message(context_type *const ctxt, 
   // Data Entry MSB
   cc.controller(control::data_entry_msb);  // 0x6
   cc.value(static_cast<std::uint8_t>((scaled_value >> 7) & 0x7F));
-  ctxt->push(cc.w);
+  ctxt->push(cc);
 
   // Data Entry LSB
   cc.controller(control::data_entry_lsb);  // 0x26
   cc.value(static_cast<std::uint8_t>(scaled_value & 0x7F));
-  ctxt->push(cc.w);
+  ctxt->push(cc);
 }
 
 // control change
@@ -156,7 +153,7 @@ void ump_to_midi1::to_midi1_config::m2cvm::control_change(context_type *const ct
                       .channel(in.channel())
                       .controller(in.controller())
                       .value(mcm_scale<m2v, m1v>(in.value()));
-  ctxt->push(cc.w);
+  ctxt->push(cc);
 }
 
 // pitch bend
@@ -168,7 +165,7 @@ void ump_to_midi1::to_midi1_config::m2cvm::pitch_bend(context_type *const ctxt, 
                        .channel(in.channel())
                        .lsb_data(scaled_value & 0x7F)
                        .msb_data((scaled_value >> 7) & 0x7F);
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 }  // end namespace midi2

--- a/src/ump_to_midi2.cpp
+++ b/src/ump_to_midi2.cpp
@@ -30,7 +30,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::note_off(ump_to_midi2::context *const
                         .channel(in.channel())
                         .note(in.note())
                         .velocity(mcm_scale<m1bits, m2bits>(in.velocity()));
-  ctxt->push(noff.w);
+  ctxt->push(noff);
 }
 
 // note on
@@ -43,7 +43,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::note_on(ump_to_midi2::context *const 
                        .channel(in.channel())
                        .note(in.note())
                        .velocity(mcm_scale<m1bits, m2bits>(in.velocity()));
-  ctxt->push(non.w);
+  ctxt->push(non);
 }
 
 // poly pressure
@@ -58,7 +58,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::poly_pressure(ump_to_midi2::context *
                        .channel(in.channel())
                        .note(in.note())
                        .pressure(mcm_scale<m1bits, m2bits>(in.pressure()));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // control change
@@ -122,7 +122,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::control_change(ump_to_midi2::context 
                          .channel(channel)
                          .controller(controller)
                          .value(mcm_scale<m1v, m2v>(value));
-    ctxt->push(out.w);
+    ctxt->push(out);
     break;
   }
   }
@@ -139,7 +139,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::program_change(ump_to_midi2::context 
   if (auto const &b = ctxt->bank[group][channel]; b.is_valid()) {
     out.bank_valid(true).bank_msb(b.msb).bank_lsb(b.lsb);
   }
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // channel pressure
@@ -151,7 +151,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::channel_pressure(ump_to_midi2::contex
 
   auto const out =
       types::m2cvm::channel_pressure{}.group(in.group()).channel(in.channel()).value(mcm_scale<m1v, m2v>(in.data()));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 // pitch bend
@@ -170,7 +170,7 @@ void ump_to_midi2::to_midi2_config::m1cvm::pitch_bend(ump_to_midi2::context *con
                        .group(in.group())
                        .channel(in.channel())
                        .value(mcm_scale<lsb_bits + msb_bits, m2v>(m1value));
-  ctxt->push(out.w);
+  ctxt->push(out);
 }
 
 }  // end namespace midi2

--- a/unittests/test_bytestream_to_ump.cpp
+++ b/unittests/test_bytestream_to_ump.cpp
@@ -294,7 +294,7 @@ TEST(BytestreamToUMP, MissingSysExEnd) {
   }
   {
     auto const noff = midi2::types::m1cvm::note_off{}.group(group).channel(channel).note(note_number).velocity(0);
-    expected.push_back(get<0>(noff.w).word());
+    expected.push_back(get<0>(noff).word());
   }
 
   auto const actual = convert(midi2::bytestream_to_ump{group}, input);
@@ -326,7 +326,7 @@ TEST(BytestreamToUMP, MissingSysExEndBeforeStart) {
   }
   {
     constexpr auto noff = midi2::types::m1cvm::note_off{}.group(group).channel(channel).note(note_number);
-    expected.push_back(get<0>(noff.w).word());
+    expected.push_back(get<0>(noff).word());
   }
 
   auto const actual = convert(midi2::bytestream_to_ump{group}, input);

--- a/unittests/test_ump_to_bytestream.cpp
+++ b/unittests/test_ump_to_bytestream.cpp
@@ -270,9 +270,8 @@ TEST(UMPToBytestream, SystemTuneRequest) {
 }
 // NOLINTNEXTLINE
 TEST(UMPToBytestream, SystemTimingClock) {
-  midi2::types::system::timing_clock message;
-  static_assert(std::tuple_size_v<decltype(message)> == 1);
-  std::array const input{get<0>(message).word()};
+  auto const [w0] = midi2::types::system::timing_clock{};
+  std::array const input{w0.word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::timing_clock)}));
 }

--- a/unittests/test_ump_to_bytestream.cpp
+++ b/unittests/test_ump_to_bytestream.cpp
@@ -48,11 +48,13 @@ TEST(UMPToBytestream, NoteOff) {
   constexpr auto note1 = 74;
   constexpr auto velocity1 = 0x7F;
 
-  std::array<midi2::types::m1cvm::note_off, 2> message;
-  message[0].group(group).channel(channel).note(note0).velocity(velocity0);
-  message[1].group(group).channel(channel).note(note1).velocity(velocity1);
+  std::vector<std::uint32_t> input;
+  auto const push_back = [&input](auto const v) { input.push_back(v.word()); };
+  midi2::types::apply(midi2::types::m1cvm::note_off{}.group(group).channel(channel).note(note0).velocity(velocity0),
+                      push_back);
+  midi2::types::apply(midi2::types::m1cvm::note_off{}.group(group).channel(channel).note(note1).velocity(velocity1),
+                      push_back);
 
-  std::array const input{get<0>(message[0].w).word(), get<0>(message[1].w).word()};
   std::array const expected{
       std::byte{to_underlying(midi2::status::note_off)} | std::byte{channel}, std::byte{note0}, std::byte{velocity0},
       std::byte{to_underlying(midi2::status::note_off)} | std::byte{channel}, std::byte{note1}, std::byte{velocity1},
@@ -68,13 +70,16 @@ TEST(UMPToBytestream, NoteOffFiltered) {
   constexpr auto note1 = 74;
   constexpr auto velocity1 = 0x7F;
 
-  std::array<midi2::types::m1cvm::note_off, 2> message;
-  // message should be filtered
-  message[0].group(group).channel(channel).note(note0).velocity(velocity0);
-  // message should not be filtered out
-  message[1].group(0).channel(channel).note(note1).velocity(velocity1);
+  std::vector<std::uint32_t> input;
+  auto const push_back = [&input](auto const v) { input.push_back(v.word()); };
 
-  std::array const input{get<0>(message[0].w).word(), get<0>(message[1].w).word()};
+  // message should be filtered
+  midi2::types::apply(midi2::types::m1cvm::note_off{}.group(group).channel(channel).note(note0).velocity(velocity0),
+                      push_back);
+  // message should not be filtered out
+  midi2::types::apply(midi2::types::m1cvm::note_off{}.group(0).channel(channel).note(note1).velocity(velocity1),
+                      push_back);
+
   std::array const expected{
       std::byte{to_underlying(midi2::status::note_off)} | std::byte{channel},
       std::byte{note1},
@@ -91,10 +96,12 @@ TEST(UMPToBytestream, NoteOn) {
   constexpr auto note1 = 74;
   constexpr auto velocity1 = 0;
 
-  std::array<midi2::types::m1cvm::note_on, 2> message;
-  message[0].channel(channel).note(note0).velocity(velocity0);
-  message[1].channel(channel).note(note1).velocity(velocity1);
-  std::array const input{get<0>(message[0].w).word(), get<0>(message[1].w).word()};
+  std::vector<std::uint32_t> input;
+  auto const push_back = [&input](auto const v) { input.push_back(v.word()); };
+
+  midi2::types::apply(midi2::types::m1cvm::note_on{}.channel(channel).note(note0).velocity(velocity0), push_back);
+  midi2::types::apply(midi2::types::m1cvm::note_on{}.channel(channel).note(note1).velocity(velocity1), push_back);
+
   std::array const expected{
       std::byte{to_underlying(midi2::status::note_on)} | std::byte{channel}, std::byte{note0}, std::byte{velocity0},
       std::byte{to_underlying(midi2::status::note_on)} | std::byte{channel}, std::byte{note1}, std::byte{velocity1},
@@ -115,6 +122,7 @@ TEST(UMPToBytestream, ControlChange) {
   message.controller(controller);
   message.value(value);
 
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
   std::array const input{get<0>(message).word()};
   std::array const expected{
       std::byte{to_underlying(midi2::status::cc)} | std::byte{channel},
@@ -128,6 +136,7 @@ TEST(UMPToBytestream, ControlChangeFilteredGroup) {
   constexpr auto group = 1U;
   constexpr auto message = midi2::types::m1cvm::control_change{}.group(group).channel(1).controller(17).value(0x71);
 
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
   std::array const input{get<0>(message).word()};
   auto const actual = convert(input, std::uint16_t{group});
   EXPECT_THAT(actual, IsEmpty());
@@ -140,6 +149,7 @@ TEST(UMPToBytestream, M1CVMChannelPressure) {
 
   constexpr auto message = midi2::types::m1cvm::channel_pressure{}.group(group).channel(channel).data(data);
 
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
   std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::channel_pressure)} | std::byte{channel},
@@ -156,7 +166,8 @@ TEST(UMPToBytestream, M1CVMPolyPressure) {
   constexpr auto message =
       midi2::types::m1cvm::poly_pressure{}.group(group).channel(channel).note(note).pressure(pressure);
 
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::poly_pressure)} | std::byte{channel},
                                   std::byte{note}, std::byte{pressure}));
@@ -171,7 +182,8 @@ TEST(UMPToBytestream, M1CVMPitchBend) {
 
   constexpr auto message = midi2::types::m1cvm::pitch_bend{}.group(group).channel(channel).lsb_data(lsb).msb_data(msb);
 
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::pitch_bend)} | std::byte{channel},
                                   std::byte{lsb}, std::byte{msb}));
@@ -184,7 +196,8 @@ TEST(UMPToBytestream, SystemTimeCode) {
   midi2::types::system::midi_time_code message;
   message.time_code(tc);
 
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::timing_code)}, std::byte{tc}));
 }
@@ -193,7 +206,8 @@ TEST(UMPToByteStream, SystemSongPositionPointer) {
   auto const lsb = 0b01111000;
   auto const msb = 0b00001111;
   constexpr auto message = midi2::types::system::song_position_pointer{}.position_lsb(lsb).position_msb(msb);
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   std::array const expected{std::byte{to_underlying(midi2::status::spp)}, std::byte{lsb}, std::byte{msb}};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAreArray(expected));
@@ -203,7 +217,8 @@ TEST(UMPToByteStream, SystemSongSelect) {
   auto const group = 1U;
   auto const song = 0x64U;
   constexpr auto message = midi2::types::system::song_select{}.group(group).song(song);
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   std::array const expected{std::byte{to_underlying(midi2::status::song_select)}, std::byte{song}};
   EXPECT_THAT(convert(input), ElementsAreArray(expected));
   EXPECT_THAT(convert(input, std::uint16_t{group}), IsEmpty());
@@ -212,10 +227,9 @@ TEST(UMPToByteStream, SystemSongSelect) {
 TEST(UMPToByteStream, SystemSequenceStart) {
   auto const group = 1U;
   midi2::types::system::sequence_start message;
-  using word0 = decltype(message)::word0;
-  auto& w0 = get<word0>(message.w);
-  w0.set<word0::group>(group);
+  message.group(group);
 
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
   std::array const input{get<0>(message).word()};
   std::array const expected{std::byte{to_underlying(midi2::status::sequence_start)}};
   auto const actual = convert(input);
@@ -225,12 +239,10 @@ TEST(UMPToByteStream, SystemSequenceStart) {
 // NOLINTNEXTLINE
 TEST(UMPToByteStream, SystemSequenceContinue) {
   auto const group = 1U;
-  midi2::types::system::sequence_continue message;
-  using word0 = decltype(message)::word0;
-  auto& w0 = get<word0>(message.w);
-  w0.set<word0::group>(group);
+  auto const message = midi2::types::system::sequence_continue{}.group(group);
 
-  std::array const input{w0.word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   std::array const expected{std::byte{to_underlying(midi2::status::sequence_continue)}};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAreArray(expected));
@@ -239,12 +251,10 @@ TEST(UMPToByteStream, SystemSequenceContinue) {
 // NOLINTNEXTLINE
 TEST(UMPToByteStream, SystemSequenceStop) {
   auto const group = 1U;
-  midi2::types::system::sequence_stop message;
-  using word0 = decltype(message)::word0;
-  auto& w0 = get<word0>(message.w);
-  w0.set<word0::group>(group);
+  auto const message = midi2::types::system::sequence_stop{}.group(group);
 
-  std::array const input{w0.word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   std::array const expected{std::byte{to_underlying(midi2::status::sequence_stop)}};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAreArray(expected));
@@ -253,26 +263,26 @@ TEST(UMPToByteStream, SystemSequenceStop) {
 // NOLINTNEXTLINE
 TEST(UMPToBytestream, SystemTuneRequest) {
   midi2::types::system::tune_request message;
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::tune_request)}));
 }
 // NOLINTNEXTLINE
 TEST(UMPToBytestream, SystemTimingClock) {
   midi2::types::system::timing_clock message;
-  std::array const input{get<0>(message.w).word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::timing_clock)}));
 }
 // NOLINTNEXTLINE
 TEST(UMPToBytestream, SystemActiveSensing) {
   auto const group = 1U;
-  midi2::types::system::active_sensing message;
-  using word0 = decltype(message)::word0;
-  auto& w0 = get<word0>(message.w);
-  w0.set<word0::group>(group);
+  auto const message = midi2::types::system::active_sensing{}.group(group);
 
-  std::array const input{w0.word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::active_sensing)}));
   EXPECT_THAT(convert(input, std::uint16_t{group}), IsEmpty());
@@ -280,12 +290,10 @@ TEST(UMPToBytestream, SystemActiveSensing) {
 // NOLINTNEXTLINE
 TEST(UMPToBytestream, SystemReset) {
   auto const group = 1U;
-  midi2::types::system::reset message;
-  using word0 = decltype(message)::word0;
-  auto& w0 = get<word0>(message.w);
-  w0.set<word0::group>(group);
+  auto const message = midi2::types::system::reset{}.group(group);
 
-  std::array const input{w0.word()};
+  static_assert(std::tuple_size_v<decltype(message)> == 1);
+  std::array const input{get<0>(message).word()};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(std::byte{to_underlying(midi2::status::systemreset)}));
   EXPECT_THAT(convert(input, std::uint16_t{group}), IsEmpty());

--- a/unittests/test_ump_to_midi1.cpp
+++ b/unittests/test_ump_to_midi1.cpp
@@ -63,8 +63,9 @@ TEST(UMPToMIDI1, M2NoteOn) {
       midi2::types::m2cvm::note_on{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
   constexpr auto expected = midi2::types::m1cvm::note_on{}.group(0).channel(0).note(note).velocity(0x60);
 
-  std::array const input{get<0>(ump.w).word(), get<1>(ump.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word()));
+  auto const& [w0, w1] = ump;
+  std::array const input{w0.word(), w1.word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2NoteOff) {
@@ -73,8 +74,9 @@ TEST(UMPToMIDI1, M2NoteOff) {
       midi2::types::m2cvm::note_off{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
   constexpr auto expected = midi2::types::m1cvm::note_off{}.group(0).channel(0).note(note).velocity(0x60);
 
-  std::array const input{get<0>(in.w).word(), get<1>(in.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word()));
+  auto const& [w0, w1] = ump;
+  std::array const input{w0.word(), w1.word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2PolyPressure) {
@@ -91,8 +93,8 @@ TEST(UMPToMIDI1, M2PolyPressure) {
   expected.note(note);
   expected.pressure(0x78);
 
-  std::array const input{get<0>(ump.w).word(), get<1>(ump.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word()));
+  std::array const input{get<0>(ump).word(), get<1>(ump).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2ProgramChangeNoBank) {
@@ -109,9 +111,9 @@ TEST(UMPToMIDI1, M2ProgramChangeNoBank) {
   expected.channel(0);
   expected.program(program);
 
-  std::array const input{get<0>(ump.w).word(), get<1>(ump.w).word()};
+  std::array const input{get<0>(ump).word(), get<1>(ump).word()};
   auto const actual = convert(input);
-  EXPECT_THAT(actual, ElementsAre(get<0>(expected.w).word()));
+  EXPECT_THAT(actual, ElementsAre(get<0>(expected).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2ProgramChangeWithBank) {
@@ -142,9 +144,9 @@ TEST(UMPToMIDI1, M2ProgramChangeWithBank) {
                                  .value(bank_lsb);
   constexpr auto expected2 = midi2::types::m1cvm::program_change{}.group(group).channel(channel).program(program);
 
-  std::array const input{get<0>(ump.w).word(), get<1>(ump.w).word()};
+  std::array const input{get<0>(ump).word(), get<1>(ump).word()};
   EXPECT_THAT(convert(input),
-              ElementsAre(get<0>(expected0.w).word(), get<0>(expected1.w).word(), get<0>(expected2.w).word()));
+              ElementsAre(get<0>(expected0).word(), get<0>(expected1).word(), get<0>(expected2).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2ChannelPressure) {
@@ -152,8 +154,8 @@ TEST(UMPToMIDI1, M2ChannelPressure) {
 
   constexpr auto expected = midi2::types::m1cvm::channel_pressure{}.group(0).channel(0).data(0x78);
 
-  std::array const input{get<0>(ump.w).word(), get<1>(ump.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word()));
+  std::array const input{get<0>(ump).word(), get<1>(ump).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2PerNotePitchBend) {
@@ -163,7 +165,7 @@ TEST(UMPToMIDI1, M2PerNotePitchBend) {
   ump.note(60);
   ump.value(0x80000000);
 
-  std::array const input{get<0>(ump.w).word(), get<1>(ump.w).word()};
+  std::array const input{get<0>(ump).word(), get<1>(ump).word()};
   EXPECT_THAT(convert(input), ElementsAre());
 }
 // NOLINTNEXTLINE
@@ -204,9 +206,9 @@ TEST(UMPToMIDI1, M2RPNController) {
   out3.controller(midi2::control::data_entry_lsb);
   out3.value(val14 & 0x7F);
 
-  std::array const input{get<0>(src.w).word(), get<1>(src.w).word()};
+  std::array const input{get<0>(src).word(), get<1>(src).word()};
   EXPECT_THAT(convert(input),
-              ElementsAre(get<0>(out0.w).word(), get<0>(out1.w).word(), get<0>(out2.w).word(), get<0>(out3.w).word()));
+              ElementsAre(get<0>(out0).word(), get<0>(out1).word(), get<0>(out2).word(), get<0>(out3).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
@@ -225,14 +227,14 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
   {
     constexpr auto src0 =
         midi2::types::m2cvm::rpn_controller{}.group(group).channel(channel).bank(bank).index(index).value(value0);
-    input.push_back(get<0>(src0.w).word());
-    input.push_back(get<1>(src0.w).word());
+    input.push_back(get<0>(src0).word());
+    input.push_back(get<1>(src0).word());
   }
   {
     constexpr auto src1 =
         midi2::types::m2cvm::rpn_controller{}.group(group).channel(channel).bank(bank).index(index).value(value1);
-    input.push_back(get<0>(src1.w).word());
-    input.push_back(get<1>(src1.w).word());
+    input.push_back(get<0>(src1).word());
+    input.push_back(get<1>(src1).word());
   }
 
   std::vector<std::uint32_t> expected;
@@ -244,7 +246,7 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
                              .channel(channel)
                              .controller(midi2::control::rpn_msb)
                              .value(bank);
-    expected.push_back(get<0>(cc0.w).word());
+    expected.push_back(get<0>(cc0).word());
   }
   {
     constexpr auto cc1 = midi2::types::m1cvm::control_change{}
@@ -252,7 +254,7 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
                              .channel(channel)
                              .controller(midi2::control::rpn_lsb)
                              .value(index);
-    expected.push_back(get<0>(cc1.w).word());
+    expected.push_back(get<0>(cc1).word());
   }
   {
     constexpr auto cc2 = midi2::types::m1cvm::control_change{}
@@ -260,7 +262,7 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
                              .channel(channel)
                              .controller(midi2::control::data_entry_msb)
                              .value((value0_14 >> 7) & 0x7F);
-    expected.push_back(get<0>(cc2.w).word());
+    expected.push_back(get<0>(cc2).word());
   }
   {
     constexpr auto cc3 = midi2::types::m1cvm::control_change{}
@@ -268,7 +270,7 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
                              .channel(channel)
                              .controller(midi2::control::data_entry_lsb)
                              .value(value0_14 & 0x7F);
-    expected.push_back(get<0>(cc3.w).word());
+    expected.push_back(get<0>(cc3).word());
   }
   {
     constexpr auto cc4 = midi2::types::m1cvm::control_change{}
@@ -276,7 +278,7 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
                              .channel(channel)
                              .controller(midi2::control::data_entry_msb)
                              .value((value1_14 >> 7) & 0x7F);
-    expected.push_back(get<0>(cc4.w).word());
+    expected.push_back(get<0>(cc4).word());
   }
   {
     constexpr auto cc5 = midi2::types::m1cvm::control_change{}
@@ -284,7 +286,7 @@ TEST(UMPToMIDI1, M2RPNControllerTwoChanges) {
                              .channel(channel)
                              .controller(midi2::control::data_entry_lsb)
                              .value(value1_14 & 0x7F);
-    expected.push_back(get<0>(cc5.w).word());
+    expected.push_back(get<0>(cc5).word());
   }
   EXPECT_THAT(convert(input), ElementsAreArray(expected));
 }
@@ -329,10 +331,9 @@ TEST(UMPToMIDI1, M2NRPNController) {
   out3.controller(midi2::control::data_entry_lsb);
   out3.value(val14 & 0x7F);
 
-  std::array const input{get<0>(src.w).word(), get<1>(src.w).word()};
+  std::array const input{get<0>(src).word(), get<1>(src).word()};
   auto const actual = convert(input);
-  EXPECT_THAT(actual,
-              ElementsAre(get<0>(out0.w).word(), get<0>(out1.w).word(), get<0>(out2.w).word(), get<0>(out3.w).word()));
+  EXPECT_THAT(actual, ElementsAre(get<0>(out0).word(), get<0>(out1).word(), get<0>(out2).word(), get<0>(out3).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, PitchBend) {
@@ -348,14 +349,14 @@ TEST(UMPToMIDI1, PitchBend) {
                                 .lsb_data((value >> (32 - 14)) & 0x7F)
                                 .msb_data(((value >> (32 - 14)) >> 7) & 0x7F);
 
-  std::array const input{get<0>(pb.w).word(), get<1>(pb.w).word()};
+  std::array const input{get<0>(pb).word(), get<1>(pb).word()};
   auto const actual = convert(input);
-  EXPECT_THAT(actual, ElementsAre(get<0>(expected.w).word()));
+  EXPECT_THAT(actual, ElementsAre(get<0>(expected).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1NoteOff) {
   midi2::types::m1cvm::note_off noff;
-  auto const ump = get<0>(noff.w).word();
+  auto const ump = get<0>(noff).word();
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -363,7 +364,7 @@ TEST(UMPToMIDI1, M1NoteOff) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1NoteOn) {
   midi2::types::m1cvm::note_on non;
-  auto const ump = get<0>(non.w).word();
+  auto const ump = get<0>(non).word();
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -371,7 +372,7 @@ TEST(UMPToMIDI1, M1NoteOn) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1PolyPressure) {
   midi2::types::m1cvm::poly_pressure poly_pressure;
-  auto const ump = get<0>(poly_pressure.w).word();
+  auto const ump = get<0>(poly_pressure).word();
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -379,7 +380,7 @@ TEST(UMPToMIDI1, M1PolyPressure) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1ControlChange) {
   midi2::types::m1cvm::control_change control_change;
-  auto const ump = get<0>(control_change.w).word();
+  auto const ump = get<0>(control_change).word();
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -387,7 +388,7 @@ TEST(UMPToMIDI1, M1ControlChange) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1ProgramChange) {
   midi2::types::m1cvm::program_change program_change;
-  auto const ump = std::bit_cast<std::uint32_t>(get<0>(program_change.w));
+  auto const ump = std::bit_cast<std::uint32_t>(get<0>(program_change));
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -395,7 +396,7 @@ TEST(UMPToMIDI1, M1ProgramChange) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1ChannelPressure) {
   midi2::types::m1cvm::channel_pressure channel_pressure;
-  auto const ump = std::bit_cast<std::uint32_t>(get<0>(channel_pressure.w));
+  auto const ump = std::bit_cast<std::uint32_t>(get<0>(channel_pressure));
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -403,7 +404,7 @@ TEST(UMPToMIDI1, M1ChannelPressure) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M1PitchBend) {
   midi2::types::m1cvm::pitch_bend pitch_bend;
-  auto const ump = std::bit_cast<std::uint32_t>(get<0>(pitch_bend.w));
+  auto const ump = std::bit_cast<std::uint32_t>(get<0>(pitch_bend));
   std::array const input{ump};
   auto const actual = convert(input);
   EXPECT_THAT(actual, ElementsAre(ump));
@@ -414,9 +415,9 @@ TEST(UMPToMIDI1, SystemMessagePassThrough) {
   std::vector<std::uint32_t> output;
   std::vector<std::uint32_t> input;
 
-  auto add = [&input]<typename T>(T const &ump) {
-    static_assert (std::tuple_size_v<decltype(T::w)> == 1);
-    input.emplace_back(std::bit_cast<std::uint32_t>(get<0>(ump.w)));
+  auto add = [&input]<typename T>(T const& ump) {
+    static_assert(std::tuple_size_v<T> == 1);
+    input.emplace_back(get<0>(ump).word());
   };
 
   add(midi2::types::system::midi_time_code{});

--- a/unittests/test_ump_to_midi1.cpp
+++ b/unittests/test_ump_to_midi1.cpp
@@ -59,8 +59,7 @@ TEST(UMPToMIDI1, SystemMessageOneByte) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2NoteOn) {
   constexpr auto note = 64;
-  constexpr auto ump =
-      midi2::types::m2cvm::note_on{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
+  constexpr auto ump = midi2::types::m2cvm::note_on{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
   constexpr auto expected = midi2::types::m1cvm::note_on{}.group(0).channel(0).note(note).velocity(0x60);
 
   auto const& [w0, w1] = ump;
@@ -70,9 +69,8 @@ TEST(UMPToMIDI1, M2NoteOn) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2NoteOff) {
   constexpr auto note = 64;
-  auto const& [w0, w1] =
-      midi2::types::m2cvm::note_off{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
-  auto const& [expected] = midi2::types::m1cvm::note_off{}.group(0).channel(0).note(note).velocity(0x60);
+  auto const [w0, w1] = midi2::types::m2cvm::note_off{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
+  auto const [expected] = midi2::types::m1cvm::note_off{}.group(0).channel(0).note(note).velocity(0x60);
   std::array const input{w0.word(), w1.word()};
   EXPECT_THAT(convert(input), ElementsAre(expected.word()));
 }

--- a/unittests/test_ump_to_midi1.cpp
+++ b/unittests/test_ump_to_midi1.cpp
@@ -59,12 +59,11 @@ TEST(UMPToMIDI1, SystemMessageOneByte) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2NoteOn) {
   constexpr auto note = 64;
-  constexpr auto ump = midi2::types::m2cvm::note_on{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
-  constexpr auto expected = midi2::types::m1cvm::note_on{}.group(0).channel(0).note(note).velocity(0x60);
-
-  auto const& [w0, w1] = ump;
+  auto const [w0, w1] =
+      midi2::types::m2cvm::note_on{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
+  auto const [expected0] = midi2::types::m1cvm::note_on{}.group(0).channel(0).note(note).velocity(0x60);
   std::array const input{w0.word(), w1.word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word()));
+  EXPECT_THAT(convert(input), ElementsAre(expected0.word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2NoteOff) {

--- a/unittests/test_ump_to_midi1.cpp
+++ b/unittests/test_ump_to_midi1.cpp
@@ -70,13 +70,11 @@ TEST(UMPToMIDI1, M2NoteOn) {
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2NoteOff) {
   constexpr auto note = 64;
-  constexpr auto in =
+  auto const& [w0, w1] =
       midi2::types::m2cvm::note_off{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
-  constexpr auto expected = midi2::types::m1cvm::note_off{}.group(0).channel(0).note(note).velocity(0x60);
-
-  auto const& [w0, w1] = ump;
+  auto const& [expected] = midi2::types::m1cvm::note_off{}.group(0).channel(0).note(note).velocity(0x60);
   std::array const input{w0.word(), w1.word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word()));
+  EXPECT_THAT(convert(input), ElementsAre(expected.word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMIDI1, M2PolyPressure) {

--- a/unittests/test_ump_to_midi2.cpp
+++ b/unittests/test_ump_to_midi2.cpp
@@ -39,8 +39,8 @@ TEST(UMPToMidi2, NoteOff) {
   constexpr auto expected =
       midi2::types::m2cvm::note_off{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
 
-  std::array const input{get<0>(in.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word(), get<1>(expected.w).word()));
+  std::array const input{get<0>(in).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word(), get<1>(expected).word()));
 }
 
 // NOLINTNEXTLINE
@@ -52,8 +52,8 @@ TEST(UMPToMidi2, NoteOn) {
   constexpr auto expected =
       midi2::types::m2cvm::note_on{}.group(0).channel(0).note(note).attribute_type(0).velocity(0xC104).attribute(0);
 
-  std::array const input{get<0>(in.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word(), get<1>(expected.w).word()));
+  std::array const input{get<0>(in).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word(), get<1>(expected).word()));
 }
 
 // UMPToMidi2
@@ -69,12 +69,12 @@ TEST(UMPToMidi2, NoteOnImplicitNoteOff) {
   {
     constexpr auto in_non_1 =
         midi2::types::m1cvm::note_on{}.group(group).channel(channel).note(note_number).velocity(velocity);
-    input.push_back(get<0>(in_non_1.w).word());
+    input.push_back(get<0>(in_non_1).word());
   }
   {
     constexpr auto in_non_2 =
         midi2::types::m1cvm::note_on{}.group(group).channel(channel).note(note_number).velocity(0);
-    input.push_back(get<0>(in_non_2.w).word());
+    input.push_back(get<0>(in_non_2).word());
   }
 
   std::vector<std::uint32_t> expected;
@@ -84,14 +84,14 @@ TEST(UMPToMidi2, NoteOnImplicitNoteOff) {
                                       .channel(channel)
                                       .note(note_number)
                                       .velocity(midi2::mcm_scale<7, 16>(velocity));
-    expected.push_back(get<0>(expected_non.w).word());
-    expected.push_back(get<1>(expected_non.w).word());
+    expected.push_back(get<0>(expected_non).word());
+    expected.push_back(get<1>(expected_non).word());
   }
   {
     constexpr auto expected_noff =
         midi2::types::m2cvm::note_on{}.group(group).channel(channel).note(note_number).velocity(0);
-    expected.push_back(get<0>(expected_noff.w).word());
-    expected.push_back(get<1>(expected_noff.w).word());
+    expected.push_back(get<0>(expected_noff).word());
+    expected.push_back(get<1>(expected_noff).word());
   }
 
   auto const actual = convert(input);
@@ -114,8 +114,8 @@ TEST(UMPToMidi2, PolyPressure) {
   expected.note(note);
   expected.pressure(midi2::mcm_scale<7, 32>(in.pressure()));
 
-  std::array const input{get<0>(in.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected.w).word(), get<1>(expected.w).word()));
+  std::array const input{get<0>(in).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(expected).word(), get<1>(expected).word()));
 }
 
 // NOLINTNEXTLINE
@@ -133,8 +133,8 @@ TEST(UMPToMidi2, PitchBend) {
   m2.channel(0);
   m2.value(midi2::mcm_scale<14, 32>(pb14));
 
-  std::array const input{get<0>(m1.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  std::array const input{get<0>(m1).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 
 // NOLINTNEXTLINE
@@ -153,8 +153,8 @@ TEST(UMPToMidi2, ChannelPressure) {
   m2.channel(channel);
   m2.value(midi2::mcm_scale<7, 32>(pressure));
 
-  std::array const input{get<0>(m1.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  std::array const input{get<0>(m1).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 // NOLINTNEXTLINE
 TEST(UMPToMidi2, SimpleContinuousController) {
@@ -175,8 +175,8 @@ TEST(UMPToMidi2, SimpleContinuousController) {
   m2.controller(controller);
   m2.value(midi2::mcm_scale<7, 32>(value));
 
-  std::array const input{get<0>(m1.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  std::array const input{get<0>(m1).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 
 // NOLINTNEXTLINE
@@ -199,8 +199,8 @@ TEST(UMPToMidi2, SimpleProgramChange) {
   m2.bank_msb(0);
   m2.bank_lsb(0);
 
-  std::array const input{get<0>(m1.w).word()};
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  std::array const input{get<0>(m1).word()};
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 
 // NOLINTNEXTLINE
@@ -219,7 +219,7 @@ TEST(UMPToMidi2, ProgramChangeWithBank) {
                                        .channel(channel)
                                        .controller(midi2::control::bank_select)
                                        .value(bank_msb);
-    input.push_back(get<0>(m1cc_bank_msb.w).word());
+    input.push_back(get<0>(m1cc_bank_msb).word());
   }
   {
     constexpr auto mc11_bank_lsb = midi2::types::m1cvm::control_change{}
@@ -227,11 +227,11 @@ TEST(UMPToMidi2, ProgramChangeWithBank) {
                                        .channel(channel)
                                        .controller(midi2::control::bank_select_lsb)
                                        .value(bank_lsb);
-    input.push_back(get<0>(mc11_bank_lsb.w).word());
+    input.push_back(get<0>(mc11_bank_lsb).word());
   }
   {
     constexpr auto m1 = midi2::types::m1cvm::program_change{}.group(group).channel(channel).program(program);
-    input.push_back(get<0>(m1.w).word());
+    input.push_back(get<0>(m1).word());
   }
 
   midi2::types::m2cvm::program_change m2;
@@ -242,7 +242,7 @@ TEST(UMPToMidi2, ProgramChangeWithBank) {
   m2.program(program);
   m2.bank_msb(bank_msb);
   m2.bank_lsb(bank_lsb);
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 
 TEST(UMPToMidi2, ControlChangeRPN) {
@@ -261,7 +261,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                                 .channel(channel)
                                 .controller(midi2::control::rpn_msb)
                                 .value(control_msb);
-    input.push_back(get<0>(pn_msb.w).word());
+    input.push_back(get<0>(pn_msb).word());
   }
   {
     constexpr auto pn_lsb = midi2::types::m1cvm::control_change{}
@@ -269,7 +269,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                                 .channel(channel)
                                 .controller(midi2::control::rpn_lsb)
                                 .value(control_lsb);
-    input.push_back(get<0>(pn_lsb.w).word());
+    input.push_back(get<0>(pn_lsb).word());
   }
   {
     constexpr auto param_value_msb = midi2::types::m1cvm::control_change{}
@@ -277,7 +277,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                                          .channel(channel)
                                          .controller(midi2::control::data_entry_msb)
                                          .value(value_msb);
-    input.push_back(get<0>(param_value_msb.w).word());
+    input.push_back(get<0>(param_value_msb).word());
   }
   {
     constexpr auto param_value_lsb = midi2::types::m1cvm::control_change{}
@@ -285,7 +285,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                                          .channel(channel)
                                          .controller(midi2::control::data_entry_lsb)
                                          .value(value_lsb);
-    input.push_back(get<0>(param_value_lsb.w).word());
+    input.push_back(get<0>(param_value_lsb).word());
   }
   {
     constexpr auto null_msb = midi2::types::m1cvm::control_change{}
@@ -293,7 +293,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                                   .channel(channel)
                                   .controller(midi2::control::rpn_msb)
                                   .value(0x7F);
-    input.push_back(get<0>(null_msb.w).word());
+    input.push_back(get<0>(null_msb).word());
   }
   {
     constexpr auto null_lsb = midi2::types::m1cvm::control_change{}
@@ -301,7 +301,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                                   .channel(channel)
                                   .controller(midi2::control::rpn_lsb)
                                   .value(0x7F);
-    input.push_back(get<0>(null_lsb.w).word());
+    input.push_back(get<0>(null_lsb).word());
   }
 
   constexpr auto m2 = midi2::types::m2cvm::rpn_controller{}
@@ -310,7 +310,7 @@ TEST(UMPToMidi2, ControlChangeRPN) {
                           .bank(control_msb)
                           .index(control_lsb)
                           .value(midi2::mcm_scale<14, 32>((std::uint32_t{value_msb} << 7) | std::uint32_t{value_lsb}));
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 
 TEST(UMPToMidi2, ControlChangeNRPN) {
@@ -337,7 +337,7 @@ TEST(UMPToMidi2, ControlChangeNRPN) {
                             .channel(channel)
                             .controller(midi2::control::nrpn_lsb)
                             .value(control_lsb);
-    input.push_back(get<0>(pn_lsb.w).word());
+    input.push_back(get<0>(pn_lsb).word());
   }
   {
     auto const param_value_msb = midi2::types::m1cvm::control_change{}
@@ -353,7 +353,7 @@ TEST(UMPToMidi2, ControlChangeNRPN) {
                                      .channel(channel)
                                      .controller(midi2::control::data_entry_lsb)
                                      .value(value_lsb);
-    input.push_back(get<0>(param_value_lsb.w).word());
+    input.push_back(get<0>(param_value_lsb).word());
   }
   {
     auto const null_msb = midi2::types::m1cvm::control_change{}
@@ -378,7 +378,7 @@ TEST(UMPToMidi2, ControlChangeNRPN) {
                       .bank(control_msb)
                       .index(control_lsb)
                       .value(midi2::mcm_scale<14, 32>((std::uint32_t{value_msb} << 7) | std::uint32_t{value_lsb}));
-  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2.w).word(), get<1>(m2.w).word()));
+  EXPECT_THAT(convert(input), ElementsAre(get<0>(m2).word(), get<1>(m2).word()));
 }
 
 template <typename T> class UMPToMidi2PassThrough : public testing::Test {


### PR DESCRIPTION
Enables elements of each of the types to be bound with structured binding.