### PR TITLE
Add dispatcher_backend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(MIDI2_HEADERS
   "${INCLUDE_DIR}/midi2/ci_create_message.hpp"
   "${INCLUDE_DIR}/midi2/ci_dispatcher.hpp"
   "${INCLUDE_DIR}/midi2/ci_types.hpp"
+  "${INCLUDE_DIR}/midi2/dispatcher_backend.hpp"
   "${INCLUDE_DIR}/midi2/icubaby.hpp"
   "${INCLUDE_DIR}/midi2/mcoded7.hpp"
   "${INCLUDE_DIR}/midi2/ump_dispatcher.hpp"

--- a/include/midi2/dispatcher_backend.hpp
+++ b/include/midi2/dispatcher_backend.hpp
@@ -1,0 +1,1191 @@
+//===-- UMP Dispatcher Backends -----------------------------------------------*- C++ -*-===//
+//
+// midi2 library under the MIT license.
+// See https://github.com/paulhuggett/AM_MIDI2.0Lib/blob/main/LICENSE for license information.
+// SPDX-License-Identifier: MIT
+//
+//===------------------------------------------------------------------------------------===//
+#ifndef MIDI2_DISPATCHER_BACKEND_HPP
+#define MIDI2_DISPATCHER_BACKEND_HPP
+
+#include <functional>
+
+#include "midi2/ump_types.hpp"
+
+namespace midi2::dispatcher_backend {
+
+// clang-format off
+template <typename T, typename Context>
+concept utility = requires(T v, Context context) {
+  // 7.2.1 NOOP
+  { v.noop(context) } -> std::same_as<void>;
+  // 7.2.2.1 JR Clock Message
+  { v.jr_clock(context, ump::utility::jr_clock{}) } -> std::same_as<void>;
+  // 7.2.2.2 JR Timestamp Message
+  { v.jr_timestamp(context, ump::utility::jr_timestamp{}) } -> std::same_as<void>;
+  // 7.2.3.1 Delta Clockstamp Ticks Per Quarter Note (DCTPQ)
+  { v.delta_clockstamp_tpqn(context, ump::utility::delta_clockstamp_tpqn{}) } -> std::same_as<void>;
+  // 7.2.3.2 Delta Clockstamp (DC): Ticks Since Last Event
+  { v.delta_clockstamp(context, ump::utility::delta_clockstamp{}) } -> std::same_as<void>;
+
+  { v.unknown(context, std::span<std::uint32_t>{}) } -> std::same_as<void>;
+};
+template <typename T, typename Context>
+concept system = requires(T v, Context context) {
+  // 7.6 System Common and System Real Time Messages
+  { v.midi_time_code(context, ump::system::midi_time_code{}) } -> std::same_as<void>;
+  { v.song_position_pointer(context, ump::system::song_position_pointer{}) } -> std::same_as<void>;
+  { v.song_select(context,  ump::system::song_select{}) } -> std::same_as<void>;
+  { v.tune_request(context,  ump::system::tune_request{}) } -> std::same_as<void>;
+  { v.timing_clock(context,  ump::system::timing_clock{}) } -> std::same_as<void>;
+  { v.seq_start(context,  ump::system::sequence_start{}) } -> std::same_as<void>;
+  { v.seq_continue(context,  ump::system::sequence_continue{}) } -> std::same_as<void>;
+  { v.seq_stop(context,  ump::system::sequence_stop{}) } -> std::same_as<void>;
+  { v.active_sensing(context,  ump::system::active_sensing{}) } -> std::same_as<void>;
+  { v.reset(context,  ump::system::reset{}) } -> std::same_as<void>;
+};
+template<typename T, typename Context>
+concept m1cvm = requires(T v, Context context) {
+  { v.note_off(context, ump::m1cvm::note_off{}) } -> std::same_as<void>;
+  { v.note_on(context, ump::m1cvm::note_on{}) } -> std::same_as<void>;
+  { v.poly_pressure(context, ump::m1cvm::poly_pressure{}) } -> std::same_as<void>;
+  { v.control_change(context, ump::m1cvm::control_change{}) } -> std::same_as<void>;
+  { v.program_change(context, ump::m1cvm::program_change{}) } -> std::same_as<void>;
+  { v.channel_pressure(context, ump::m1cvm::channel_pressure{}) } -> std::same_as<void>;
+  { v.pitch_bend(context, ump::m1cvm::pitch_bend{}) } -> std::same_as<void>;
+};
+template <typename T, typename Context>
+concept data64 = requires(T v, Context context) {
+  { v.sysex7_in_1(context, ump::data64::sysex7_in_1{}) } -> std::same_as<void>;
+  { v.sysex7_start(context, ump::data64::sysex7_start{}) } -> std::same_as<void>;
+  { v.sysex7_continue(context, ump::data64::sysex7_continue{}) } -> std::same_as<void>;
+  { v.sysex7_end(context, ump::data64::sysex7_end{}) } -> std::same_as<void>;
+};
+template <typename T, typename Context>
+concept m2cvm = requires(T v, Context context) {
+  // 7.4.1 MIDI 2.0 Note Off Message (status=0x8)
+  { v.note_off(context, ump::m2cvm::note_off{}) } -> std::same_as<void>;
+  // 7.4.2 MIDI 2.0 Note On Message (status=0x9)
+  { v.note_on(context, ump::m2cvm::note_on{}) } -> std::same_as<void>;
+  // 7.4.3 MIDI 2.0 Poly Pressure Message (status=0xA)
+  { v.poly_pressure(context, ump::m2cvm::poly_pressure{}) } -> std::same_as<void>;
+
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x0)
+  { v.rpn_per_note_controller(context, midi2::ump::m2cvm::rpn_per_note_controller{}) } -> std::same_as<void>;
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x1)
+  { v.nrpn_per_note_controller(context, midi2::ump::m2cvm::nrpn_per_note_controller{}) } -> std::same_as<void>;
+  // 7.4.7 MIDI 2.0 Registered Controller (RPN) Message (status=0x2)
+  { v.rpn_controller(context, midi2::ump::m2cvm::rpn_controller{}) } -> std::same_as<void>;
+  // 7.4.7 MIDI 2.0 Assignable Controller (NRPN) Message (status=0x3)
+  { v.nrpn_controller(context, midi2::ump::m2cvm::nrpn_controller{}) } -> std::same_as<void>;
+  // 7.4.8 MIDI 2.0 Relative Registered Controller (RPN) Message (status=0x4)
+  { v.rpn_relative_controller(context, midi2::ump::m2cvm::rpn_relative_controller{}) } -> std::same_as<void>;
+  // 7.4.8 MIDI 2.0 Relative Assignable Controller (NRPN) Message (status=0x5)
+  { v.nrpn_relative_controller(context, midi2::ump::m2cvm::nrpn_relative_controller{}) } -> std::same_as<void>;
+
+  // 7.4.9 MIDI 2.0 Program Change Message (status=0xC)
+  { v.program_change(context, ump::m2cvm::program_change{}) } -> std::same_as<void>;
+  // 7.4.10 MIDI 2.0 Channel Pressure Message (status=0xD)
+  { v.channel_pressure(context, ump::m2cvm::channel_pressure{}) } -> std::same_as<void>;
+
+  { v.per_note_management(context, ump::m2cvm::per_note_management{}) } -> std::same_as<void>;
+  { v.control_change(context, ump::m2cvm::control_change{}) } -> std::same_as<void>;
+
+  { v.pitch_bend(context, ump::m2cvm::pitch_bend{}) } -> std::same_as<void>;
+  { v.per_note_pitch_bend(context, ump::m2cvm::per_note_pitch_bend{}) } -> std::same_as<void>;
+};
+template <typename T, typename Context>
+concept data128 = requires(T v, Context context) {
+  // 7.8 System Exclusive 8 (8-Bit) Messages
+  { v.sysex8_in_1(context, ump::data128::sysex8_in_1{}) } -> std::same_as<void>;
+  { v.sysex8_start(context, ump::data128::sysex8_start{}) } -> std::same_as<void>;
+  { v.sysex8_continue(context, ump::data128::sysex8_continue{}) } -> std::same_as<void>;
+  { v.sysex8_end(context, ump::data128::sysex8_end{}) } -> std::same_as<void>;
+  // 7.9 Mixed Data Set Message
+  { v.mds_header(context, ump::data128::mds_header{}) } -> std::same_as<void>;
+  { v.mds_payload(context, ump::data128::mds_payload{}) } -> std::same_as<void>;
+};
+template <typename T, typename Context>
+concept ump_stream = requires(T v, Context context) {
+  { v.endpoint_discovery(context, ump::ump_stream::endpoint_discovery{}) } -> std::same_as<void>;
+  { v.endpoint_info_notification(context, ump::ump_stream::endpoint_info_notification{}) } -> std::same_as<void>;
+  { v.device_identity_notification(context, ump::ump_stream::device_identity_notification{}) } -> std::same_as<void>;
+  { v.endpoint_name_notification(context, ump::ump_stream::endpoint_name_notification{}) } -> std::same_as<void>;
+  { v.product_instance_id_notification(context, ump::ump_stream::product_instance_id_notification{}) } -> std::same_as<void>;
+  { v.jr_configuration_request(context, ump::ump_stream::jr_configuration_request{}) } -> std::same_as<void>;
+  { v.jr_configuration_notification(context, ump::ump_stream::jr_configuration_notification{}) } -> std::same_as<void>;
+  { v.function_block_discovery(context, ump::ump_stream::function_block_discovery{}) } -> std::same_as<void>;
+  { v.function_block_info_notification(context, ump::ump_stream::function_block_info_notification{}) } -> std::same_as<void>;
+  { v.function_block_name_notification(context, ump::ump_stream::function_block_name_notification{}) } -> std::same_as<void>;
+  { v.start_of_clip(context, ump::ump_stream::start_of_clip{}) } -> std::same_as<void>;
+  { v.end_of_clip(context, ump::ump_stream::end_of_clip{}) } -> std::same_as<void>;
+};
+template <typename T, typename Context>
+concept flex_data = requires(T v, Context context) {
+  { v.set_tempo(context, ump::flex_data::set_tempo{}) } -> std::same_as<void>;
+  { v.set_time_signature(context, ump::flex_data::set_time_signature{}) } -> std::same_as<void>;
+  { v.set_metronome(context, ump::flex_data::set_metronome{}) } -> std::same_as<void>;
+  { v.set_key_signature(context, ump::flex_data::set_key_signature{}) } -> std::same_as<void>;
+  { v.set_chord_name(context, ump::flex_data::set_chord_name{}) } -> std::same_as<void>;
+  { v.text(context, ump::flex_data::text_common{}) } -> std::same_as<void>;
+};
+// clang-format on
+
+template <typename Context> struct utility_null {
+  // 7.2.1 NOOP
+  constexpr static void noop(Context) { /* do nothing */ }
+  // 7.2.2.1 JR Clock Message
+  constexpr static void jr_clock(Context, ump::utility::jr_clock const &) { /* do nothing */ }
+  // 7.2.2.2 JR Timestamp Message
+  constexpr static void jr_timestamp(Context, ump::utility::jr_timestamp const &) { /* do nothing */ }
+  // 7.2.3.1 Delta Clockstamp Ticks Per Quarter Note (DCTPQ)
+  constexpr static void delta_clockstamp_tpqn(Context, ump::utility::delta_clockstamp_tpqn const &) { /* do nothing */ }
+  // 7.2.3.2 Delta Clockstamp (DC): Ticks Since Last Event
+  constexpr static void delta_clockstamp(Context, ump::utility::delta_clockstamp const &) { /* do nothing */ }
+
+  constexpr static void unknown(Context, std::span<std::uint32_t>) { /* do nothing */ }
+};
+
+static_assert(utility<utility_null<int>, int>);
+
+template <typename Context> struct system_null {
+  // 7.6 System Common and System Real Time Messages
+  constexpr static void midi_time_code(Context, ump::system::midi_time_code const &) { /* do nothing */ }
+  constexpr static void song_position_pointer(Context, ump::system::song_position_pointer const &) { /* do nothing */ }
+  constexpr static void song_select(Context, ump::system::song_select const &) { /* do nothing */ }
+  constexpr static void tune_request(Context, ump::system::tune_request const &) { /* do nothing */ }
+  constexpr static void timing_clock(Context, ump::system::timing_clock const &) { /* do nothing */ }
+  constexpr static void seq_start(Context, ump::system::sequence_start const &) { /* do nothing */ }
+  constexpr static void seq_continue(Context, ump::system::sequence_continue const &) { /* do nothing */ }
+  constexpr static void seq_stop(Context, ump::system::sequence_stop const &) { /* do nothing */ }
+  constexpr static void active_sensing(Context, ump::system::active_sensing const &) { /* do nothing */ }
+  constexpr static void reset(Context, ump::system::reset const &) { /* do nothing */ }
+};
+
+static_assert(system<system_null<int>, int>);
+
+template <typename Context> struct m1cvm_null {
+  constexpr static void note_off(Context, ump::m1cvm::note_off const &) { /* do nothing */ }
+  constexpr static void note_on(Context, ump::m1cvm::note_on const &) { /* do nothing */ }
+  constexpr static void poly_pressure(Context, ump::m1cvm::poly_pressure const &) { /* do nothing */ }
+  constexpr static void control_change(Context, ump::m1cvm::control_change const &) { /* do nothing */ }
+  constexpr static void program_change(Context, ump::m1cvm::program_change const &) { /* do nothing */ }
+  constexpr static void channel_pressure(Context, ump::m1cvm::channel_pressure const &) { /* do nothing */ }
+  constexpr static void pitch_bend(Context, ump::m1cvm::pitch_bend const &) { /* do nothing */ }
+};
+
+static_assert(m1cvm<m1cvm_null<int>, int>);
+
+template <typename Context> struct data64_null {
+  constexpr static void sysex7_in_1(Context, ump::data64::sysex7_in_1 const &) { /* do nothing */ }
+  constexpr static void sysex7_start(Context, ump::data64::sysex7_start const &) { /* do nothing */ }
+  constexpr static void sysex7_continue(Context, ump::data64::sysex7_continue const &) { /* do nothing */ }
+  constexpr static void sysex7_end(Context, ump::data64::sysex7_end const &) { /* do nothing */ }
+};
+
+static_assert(data64<data64_null<int>, int>);
+
+template <typename Context> struct m2cvm_null {
+  constexpr static void note_off(Context, ump::m2cvm::note_off const &) { /* do nothing */ }
+  constexpr static void note_on(Context, ump::m2cvm::note_on const &) { /* do nothing */ }
+  constexpr static void poly_pressure(Context, ump::m2cvm::poly_pressure const &) { /* do nothing */ }
+  constexpr static void program_change(Context, ump::m2cvm::program_change const &) { /* do nothing */ }
+  constexpr static void channel_pressure(Context, ump::m2cvm::channel_pressure const &) { /* do nothing */ }
+
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x0)
+  constexpr static void rpn_per_note_controller(Context, ump::m2cvm::rpn_per_note_controller const &) { /* do nothing */
+  }
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x1)
+  constexpr static void nrpn_per_note_controller(Context,
+                                                 ump::m2cvm::nrpn_per_note_controller const &) { /* do nothing */ }
+  // 7.4.7 MIDI 2.0 Registered Controller (RPN) Message (status=0x2)
+  constexpr static void rpn_controller(Context, ump::m2cvm::rpn_controller const &) { /* do nothing */ }
+  // 7.4.7 MIDI 2.0 Assignable Controller (NRPN) Message (status=0x3)
+  constexpr static void nrpn_controller(Context, ump::m2cvm::nrpn_controller const &) { /* do nothing */ }
+  // 7.4.8 MIDI 2.0 Relative Registered Controller (RPN) Message (status=0x4)
+  constexpr static void rpn_relative_controller(Context, ump::m2cvm::rpn_relative_controller const &) { /* do nothing */
+  }
+  // 7.4.8 MIDI 2.0 Relative Assignable Controller (NRPN) Message (status=0x5)
+  constexpr static void nrpn_relative_controller(Context,
+                                                 ump::m2cvm::nrpn_relative_controller const &) { /* do nothing */ }
+
+  constexpr static void per_note_management(Context, ump::m2cvm::per_note_management const &) { /* do nothing */ }
+  constexpr static void control_change(Context, ump::m2cvm::control_change const &) { /* do nothing */ }
+  constexpr static void pitch_bend(Context, ump::m2cvm::pitch_bend const &) { /* do nothing */ }
+  constexpr static void per_note_pitch_bend(Context, ump::m2cvm::per_note_pitch_bend const &) { /* do nothing */ }
+};
+
+static_assert(m2cvm<m2cvm_null<int>, int>);
+
+template <typename Context> struct data128_null {
+  constexpr static void sysex8_in_1(Context, ump::data128::sysex8_in_1 const &) { /* do nothing */ }
+  constexpr static void sysex8_start(Context, ump::data128::sysex8_start const &) { /* do nothing */ }
+  constexpr static void sysex8_continue(Context, ump::data128::sysex8_continue const &) { /* do nothing */ }
+  constexpr static void sysex8_end(Context, ump::data128::sysex8_end const &) { /* do nothing */ }
+  constexpr static void mds_header(Context, ump::data128::mds_header const &) { /* do nothing */ }
+  constexpr static void mds_payload(Context, ump::data128::mds_payload const &) { /* do nothing */ }
+};
+
+static_assert(data128<data128_null<int>, int>);
+
+template <typename Context> struct ump_stream_null {
+  constexpr static void endpoint_discovery(Context, ump::ump_stream::endpoint_discovery const &) { /* do nothing */ }
+  constexpr static void endpoint_info_notification(
+      Context, ump::ump_stream::endpoint_info_notification const &) { /* do nothing */ }
+  constexpr static void device_identity_notification(
+      Context, ump::ump_stream::device_identity_notification const &) { /* do nothing */ }
+  constexpr static void endpoint_name_notification(
+      Context, ump::ump_stream::endpoint_name_notification const &) { /* do nothing */ }
+  constexpr static void product_instance_id_notification(
+      Context, ump::ump_stream::product_instance_id_notification const &) { /* do nothing */ }
+  constexpr static void jr_configuration_request(Context,
+                                                 ump::ump_stream::jr_configuration_request const &) { /* do nothing */ }
+  constexpr static void jr_configuration_notification(
+      Context, ump::ump_stream::jr_configuration_notification const &) { /* do nothing */ }
+
+  constexpr static void function_block_discovery(Context,
+                                                 ump::ump_stream::function_block_discovery const &) { /* do nothing */ }
+  constexpr static void function_block_info_notification(
+      Context, ump::ump_stream::function_block_info_notification const &) { /* do nothing */ }
+  constexpr static void function_block_name_notification(
+      Context, ump::ump_stream::function_block_name_notification const &) { /* do nothing */ }
+
+  constexpr static void start_of_clip(Context, ump::ump_stream::start_of_clip const &) { /* do nothing */ }
+  constexpr static void end_of_clip(Context, ump::ump_stream::end_of_clip const &) { /* do nothing */ }
+};
+
+static_assert(ump_stream<ump_stream_null<int>, int>);
+
+template <typename Context> struct flex_data_null {
+  constexpr static void set_tempo(Context, ump::flex_data::set_tempo const &) { /* do nothing */ }
+  constexpr static void set_time_signature(Context, ump::flex_data::set_time_signature const &) { /* do nothing */ }
+  constexpr static void set_metronome(Context, ump::flex_data::set_metronome const &) { /* do nothing */ }
+  constexpr static void set_key_signature(Context, ump::flex_data::set_key_signature const &) { /* do nothing */ }
+  constexpr static void set_chord_name(Context, ump::flex_data::set_chord_name const &) { /* do nothing */ }
+  constexpr static void text(Context, ump::flex_data::text_common const &) { /* do nothing */ }
+};
+
+static_assert(flex_data<flex_data_null<int>, int>);
+
+template <typename Context> struct utility_pure {
+  virtual ~utility_pure() noexcept = default;
+
+  // 7.2.1 NOOP
+  virtual void noop(Context) = 0;
+  // 7.2.2.1 JR Clock Message
+  virtual void jr_clock(Context, ump::utility::jr_clock const &) = 0;
+  // 7.2.2.2 JR Timestamp Message
+  virtual void jr_timestamp(Context, ump::utility::jr_timestamp const &) = 0;
+  // 7.2.3.1 Delta Clockstamp Ticks Per Quarter Note (DCTPQ)
+  virtual void delta_clockstamp_tpqn(Context, ump::utility::delta_clockstamp_tpqn const &) = 0;
+  // 7.2.3.2 Delta Clockstamp (DC): Ticks Since Last Event
+  virtual void delta_clockstamp(Context, ump::utility::delta_clockstamp const &) = 0;
+
+  virtual void unknown(Context, std::span<std::uint32_t>) = 0;
+};
+
+static_assert(utility<utility_pure<int>, int>);
+
+template <typename Context> struct system_pure {
+  virtual ~system_pure() = default;
+
+  // 7.6 System Common and System Real Time Messages
+  virtual void midi_time_code(Context, ump::system::midi_time_code const &) = 0;
+  virtual void song_position_pointer(Context, ump::system::song_position_pointer const &) = 0;
+  virtual void song_select(Context, ump::system::song_select const &) = 0;
+  virtual void tune_request(Context, ump::system::tune_request const &) = 0;
+  virtual void timing_clock(Context, ump::system::timing_clock const &) = 0;
+  virtual void seq_start(Context, ump::system::sequence_start const &) = 0;
+  virtual void seq_continue(Context, ump::system::sequence_continue const &) = 0;
+  virtual void seq_stop(Context, ump::system::sequence_stop const &) = 0;
+  virtual void active_sensing(Context, ump::system::active_sensing const &) = 0;
+  virtual void reset(Context, ump::system::reset const &) = 0;
+};
+
+static_assert(system<system_pure<int>, int>);
+
+template <typename Context> struct m1cvm_pure {
+  virtual ~m1cvm_pure() = default;
+
+  virtual void note_off(Context, ump::m1cvm::note_off const &) = 0;
+  virtual void note_on(Context, ump::m1cvm::note_on const &) = 0;
+  virtual void poly_pressure(Context, ump::m1cvm::poly_pressure const &) = 0;
+  virtual void control_change(Context, ump::m1cvm::control_change const &) = 0;
+  virtual void program_change(Context, ump::m1cvm::program_change const &) = 0;
+  virtual void channel_pressure(Context, ump::m1cvm::channel_pressure const &) = 0;
+  virtual void pitch_bend(Context, ump::m1cvm::pitch_bend const &) = 0;
+};
+
+static_assert(m1cvm<m1cvm_pure<int>, int>);
+
+template <typename Context> struct data64_pure {
+  virtual ~data64_pure() = default;
+
+  virtual void sysex7_in_1(Context, ump::data64::sysex7_in_1 const &) = 0;
+  virtual void sysex7_start(Context, ump::data64::sysex7_start const &) = 0;
+  virtual void sysex7_continue(Context, ump::data64::sysex7_continue const &) = 0;
+  virtual void sysex7_end(Context, ump::data64::sysex7_end const &) = 0;
+};
+
+static_assert(data64<data64_pure<int>, int>);
+
+template <typename Context> struct m2cvm_pure {
+  virtual ~m2cvm_pure() = default;
+
+  virtual void note_off(Context, ump::m2cvm::note_off const &) = 0;
+  virtual void note_on(Context, ump::m2cvm::note_on const &) = 0;
+  virtual void poly_pressure(Context, ump::m2cvm::poly_pressure const &) = 0;
+  virtual void program_change(Context, ump::m2cvm::program_change const &) = 0;
+  virtual void channel_pressure(Context, ump::m2cvm::channel_pressure const &) = 0;
+
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x0)
+  virtual void rpn_per_note_controller(Context, ump::m2cvm::rpn_per_note_controller const &) = 0;
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x1)
+  virtual void nrpn_per_note_controller(Context, ump::m2cvm::nrpn_per_note_controller const &) = 0;
+  // 7.4.7 MIDI 2.0 Registered Controller (RPN) Message (status=0x2)
+  virtual void rpn_controller(Context, ump::m2cvm::rpn_controller const &) = 0;
+  // 7.4.7 MIDI 2.0 Assignable Controller (NRPN) Message (status=0x3)
+  virtual void nrpn_controller(Context, ump::m2cvm::nrpn_controller const &) = 0;
+  // 7.4.8 MIDI 2.0 Relative Registered Controller (RPN) Message (status=0x4)
+  virtual void rpn_relative_controller(Context, ump::m2cvm::rpn_relative_controller const &) = 0;
+  // 7.4.8 MIDI 2.0 Relative Assignable Controller (NRPN) Message (status=0x5)
+  virtual void nrpn_relative_controller(Context, ump::m2cvm::nrpn_relative_controller const &) = 0;
+
+  virtual void per_note_management(Context, ump::m2cvm::per_note_management const &) = 0;
+  virtual void control_change(Context, ump::m2cvm::control_change const &) = 0;
+  virtual void pitch_bend(Context, ump::m2cvm::pitch_bend const &) = 0;
+  virtual void per_note_pitch_bend(Context, ump::m2cvm::per_note_pitch_bend const &) = 0;
+};
+
+static_assert(m2cvm<m2cvm_pure<int>, int>);
+
+template <typename Context> struct data128_pure {
+  virtual ~data128_pure() = default;
+
+  virtual void sysex8_in_1(Context, ump::data128::sysex8_in_1 const &) = 0;
+  virtual void sysex8_start(Context, ump::data128::sysex8_start const &) = 0;
+  virtual void sysex8_continue(Context, ump::data128::sysex8_continue const &) = 0;
+  virtual void sysex8_end(Context, ump::data128::sysex8_end const &) = 0;
+  virtual void mds_header(Context, ump::data128::mds_header const &) = 0;
+  virtual void mds_payload(Context, ump::data128::mds_payload const &) = 0;
+};
+
+static_assert(data128<data128_pure<int>, int>);
+
+template <typename Context> struct ump_stream_pure {
+  virtual ~ump_stream_pure() = default;
+
+  virtual void endpoint_discovery(Context, ump::ump_stream::endpoint_discovery const &) = 0;
+  virtual void endpoint_info_notification(Context, ump::ump_stream::endpoint_info_notification const &) = 0;
+  virtual void device_identity_notification(Context, ump::ump_stream::device_identity_notification const &) = 0;
+  virtual void endpoint_name_notification(Context, ump::ump_stream::endpoint_name_notification const &) = 0;
+  virtual void product_instance_id_notification(Context, ump::ump_stream::product_instance_id_notification const &) = 0;
+  virtual void jr_configuration_request(Context, ump::ump_stream::jr_configuration_request const &) = 0;
+  virtual void jr_configuration_notification(Context, ump::ump_stream::jr_configuration_notification const &) = 0;
+
+  virtual void function_block_discovery(Context, ump::ump_stream::function_block_discovery const &) = 0;
+  virtual void function_block_info_notification(Context, ump::ump_stream::function_block_info_notification const &) = 0;
+  virtual void function_block_name_notification(Context, ump::ump_stream::function_block_name_notification const &) = 0;
+
+  virtual void start_of_clip(Context, ump::ump_stream::start_of_clip const &) = 0;
+  virtual void end_of_clip(Context, ump::ump_stream::end_of_clip const &) = 0;
+};
+
+static_assert(ump_stream<ump_stream_pure<int>, int>);
+
+template <typename Context> struct flex_data_pure {
+  virtual ~flex_data_pure() = default;
+
+  virtual void set_tempo(Context, ump::flex_data::set_tempo const &) = 0;
+  virtual void set_time_signature(Context, ump::flex_data::set_time_signature const &) = 0;
+  virtual void set_metronome(Context, ump::flex_data::set_metronome const &) = 0;
+  virtual void set_key_signature(Context, ump::flex_data::set_key_signature const &) = 0;
+  virtual void set_chord_name(Context, ump::flex_data::set_chord_name const &) = 0;
+  virtual void text(Context, ump::flex_data::text_common const &) = 0;
+};
+
+static_assert(flex_data<flex_data_pure<int>, int>);
+
+template <typename Context> struct utility_base : public utility_pure<Context> {
+  // 7.2.1 NOOP
+  void noop(Context) override { /* do nothing */ }
+  // 7.2.2.1 JR Clock Message
+  void jr_clock(Context, ump::utility::jr_clock const &) override { /* do nothing */ }
+  // 7.2.2.2 JR Timestamp Message
+  void jr_timestamp(Context, ump::utility::jr_timestamp const &) override { /* do nothing */ }
+  // 7.2.3.1 Delta Clockstamp Ticks Per Quarter Note (DCTPQ)
+  void delta_clockstamp_tpqn(Context, ump::utility::delta_clockstamp_tpqn const &) override { /* do nothing */ }
+  // 7.2.3.2 Delta Clockstamp (DC): Ticks Since Last Event
+  void delta_clockstamp(Context, ump::utility::delta_clockstamp const &) override { /* do nothing */ }
+
+  void unknown(Context, std::span<std::uint32_t>) override { /* do nothing */ }
+};
+template <typename Context> struct system_base : public system_pure<Context> {
+  // 7.6 System Common and System Real Time Messages
+  void midi_time_code(Context, ump::system::midi_time_code const &) override { /* do nothing */ }
+  void song_position_pointer(Context, ump::system::song_position_pointer const &) override { /* do nothing */ }
+  void song_select(Context, ump::system::song_select const &) override { /* do nothing */ }
+  void tune_request(Context, ump::system::tune_request const &) override { /* do nothing */ }
+  void timing_clock(Context, ump::system::timing_clock const &) override { /* do nothing */ }
+  void seq_start(Context, ump::system::sequence_start const &) override { /* do nothing */ }
+  void seq_continue(Context, ump::system::sequence_continue const &) override { /* do nothing */ }
+  void seq_stop(Context, ump::system::sequence_stop const &) override { /* do nothing */ }
+  void active_sensing(Context, ump::system::active_sensing const &) override { /* do nothing */ }
+  void reset(Context, ump::system::reset const &) override { /* do nothing */ }
+};
+template <typename Context> struct m1cvm_base : public m1cvm_pure<Context> {
+  void note_off(Context, ump::m1cvm::note_off const &) override { /* do nothing */ }
+  void note_on(Context, ump::m1cvm::note_on const &) override { /* do nothing */ }
+  void poly_pressure(Context, ump::m1cvm::poly_pressure const &) override { /* do nothing */ }
+  void control_change(Context, ump::m1cvm::control_change const &) override { /* do nothing */ }
+  void program_change(Context, ump::m1cvm::program_change const &) override { /* do nothing */ }
+  void channel_pressure(Context, ump::m1cvm::channel_pressure const &) override { /* do nothing */ }
+  void pitch_bend(Context, ump::m1cvm::pitch_bend const &) override { /* do nothing */ }
+};
+template <typename Context> struct data64_base : public data64_pure<Context> {
+  void sysex7_in_1(Context, ump::data64::sysex7_in_1 const &) override { /* do nothing */ }
+  void sysex7_start(Context, ump::data64::sysex7_start const &) override { /* do nothing */ }
+  void sysex7_continue(Context, ump::data64::sysex7_continue const &) override { /* do nothing */ }
+  void sysex7_end(Context, ump::data64::sysex7_end const &) override { /* do nothing */ }
+};
+template <typename Context> struct m2cvm_base : public m2cvm_pure<Context> {
+  void note_off(Context, ump::m2cvm::note_off const &) override { /* do nothing */ }
+  void note_on(Context, ump::m2cvm::note_on const &) override { /* do nothing */ }
+  void poly_pressure(Context, ump::m2cvm::poly_pressure const &) override { /* do nothing */ }
+  void program_change(Context, ump::m2cvm::program_change const &) override { /* do nothing */ }
+  void channel_pressure(Context, ump::m2cvm::channel_pressure const &) override { /* do nothing */ }
+
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x0)
+  void rpn_per_note_controller(Context, ump::m2cvm::rpn_per_note_controller const &) override { /* do nothing */ }
+  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x1)
+  void nrpn_per_note_controller(Context, ump::m2cvm::nrpn_per_note_controller const &) override { /* do nothing */ }
+  // 7.4.7 MIDI 2.0 Registered Controller (RPN) Message (status=0x2)
+  void rpn_controller(Context, ump::m2cvm::rpn_controller const &) override { /* do nothing */ }
+  // 7.4.7 MIDI 2.0 Assignable Controller (NRPN) Message (status=0x3)
+  void nrpn_controller(Context, ump::m2cvm::nrpn_controller const &) override { /* do nothing */ }
+  // 7.4.8 MIDI 2.0 Relative Registered Controller (RPN) Message (status=0x4)
+  void rpn_relative_controller(Context, ump::m2cvm::rpn_relative_controller const &) override { /* do nothing */ }
+  // 7.4.8 MIDI 2.0 Relative Assignable Controller (NRPN) Message (status=0x5)
+  void nrpn_relative_controller(Context, ump::m2cvm::nrpn_relative_controller const &) override { /* do nothing */ }
+
+  void per_note_management(Context, ump::m2cvm::per_note_management const &) override { /* do nothing */ }
+  void control_change(Context, ump::m2cvm::control_change const &) override { /* do nothing */ }
+  void pitch_bend(Context, ump::m2cvm::pitch_bend const &) override { /* do nothing */ }
+  void per_note_pitch_bend(Context, ump::m2cvm::per_note_pitch_bend const &) override { /* do nothing */ }
+};
+template <typename Context> struct data128_base : public data128_pure<Context> {
+  void sysex8_in_1(Context, ump::data128::sysex8_in_1 const &) override { /* do nothing */ }
+  void sysex8_start(Context, ump::data128::sysex8_start const &) override { /* do nothing */ }
+  void sysex8_continue(Context, ump::data128::sysex8_continue const &) override { /* do nothing */ }
+  void sysex8_end(Context, ump::data128::sysex8_end const &) override { /* do nothing */ }
+  void mds_header(Context, ump::data128::mds_header const &) override { /* do nothing */ }
+  void mds_payload(Context, ump::data128::mds_payload const &) override { /* do nothing */ }
+};
+template <typename Context> struct ump_stream_base : public ump_stream_pure<Context> {
+  void endpoint_discovery(Context, ump::ump_stream::endpoint_discovery const &) override { /* do nothing */ }
+  void endpoint_info_notification(Context,
+                                  ump::ump_stream::endpoint_info_notification const &) override { /* do nothing */ }
+  void device_identity_notification(Context,
+                                    ump::ump_stream::device_identity_notification const &) override { /* do nothing */ }
+  void endpoint_name_notification(Context,
+                                  ump::ump_stream::endpoint_name_notification const &) override { /* do nothing */ }
+  void product_instance_id_notification(
+      Context, ump::ump_stream::product_instance_id_notification const &) override { /* do nothing */ }
+  void jr_configuration_request(Context, ump::ump_stream::jr_configuration_request const &) override { /* do nothing */
+  }
+  void jr_configuration_notification(Context,
+                                     ump::ump_stream::jr_configuration_notification const &) override { /* do nothing */
+  }
+
+  void function_block_discovery(Context, ump::ump_stream::function_block_discovery const &) override { /* do nothing */
+  }
+  void function_block_info_notification(
+      Context, ump::ump_stream::function_block_info_notification const &) override { /* do nothing */ }
+  void function_block_name_notification(
+      Context, ump::ump_stream::function_block_name_notification const &) override { /* do nothing */ }
+
+  void start_of_clip(Context, ump::ump_stream::start_of_clip const &) override { /* do nothing */ }
+  void end_of_clip(Context, ump::ump_stream::end_of_clip const &) override { /* do nothing */ }
+};
+template <typename Context> struct flex_data_base : public flex_data_pure<Context> {
+  void set_tempo(Context, ump::flex_data::set_tempo const &) override { /* do nothing */ }
+  void set_time_signature(Context, ump::flex_data::set_time_signature const &) override { /* do nothing */ }
+  void set_metronome(Context, ump::flex_data::set_metronome const &) override { /* do nothing */ }
+  void set_key_signature(Context, ump::flex_data::set_key_signature const &) override { /* do nothing */ }
+  void set_chord_name(Context, ump::flex_data::set_chord_name const &) override { /* do nothing */ }
+  void text(Context, ump::flex_data::text_common const &) override { /* do nothing */ }
+};
+
+namespace details {
+
+template <typename Function, typename Context> void call(Function const &function, Context &&context) {
+  if (function) {
+    function(std::forward<Context>(context));
+  }
+}
+template <typename Function, typename Context, typename Argument>
+void call(Function const &function, Context &&context, Argument &&argument) {
+  if (function) {
+    function(std::forward<Context>(context), std::forward<Argument>(argument));
+  }
+}
+
+}  // end namespace details
+
+template <typename Context> class utility_fn {
+public:
+  using noop_fn = std::function<void(Context)>;
+  using jr_clock_fn = std::function<void(Context, ump::utility::jr_clock const &)>;
+  using jr_timestamp_fn = std::function<void(Context, ump::utility::jr_timestamp const &)>;
+  using delta_clockstamp_tpqn_fn = std::function<void(Context, ump::utility::delta_clockstamp_tpqn const &)>;
+  using delta_clockstamp_fn = std::function<void(Context, ump::utility::delta_clockstamp const &)>;
+  using unknown_fn = std::function<void(Context, std::span<std::uint32_t>)>;
+
+  constexpr utility_fn &on_noop(noop_fn noop) noexcept {
+    noop_ = std::move(noop);
+    return *this;
+  }
+  constexpr utility_fn &on_jr_clock(jr_clock_fn jr_clock) noexcept {
+    jr_clock_ = std::move(jr_clock);
+    return *this;
+  }
+  constexpr utility_fn &on_jr_timestamp(jr_timestamp_fn jr_timestamp) noexcept {
+    jr_timestamp_ = std::move(jr_timestamp);
+    return *this;
+  }
+  constexpr utility_fn &on_delta_clockstamp_tpqn(delta_clockstamp_tpqn_fn delta_clockstamp) noexcept {
+    delta_clockstamp_tpqn_ = std::move(delta_clockstamp);
+    return *this;
+  }
+  constexpr utility_fn &on_delta_clockstamp(delta_clockstamp_fn delta_clockstamp) noexcept {
+    delta_clockstamp_ = std::move(delta_clockstamp);
+    return *this;
+  }
+  constexpr utility_fn &on_unknown(unknown_fn unknown) noexcept {
+    unknown_ = std::move(unknown);
+    return *this;
+  }
+
+  void noop(Context context) { details::call(noop_, context); }
+  void jr_clock(Context context, ump::utility::jr_clock const &clock) { details::call(jr_clock_, context, clock); }
+  void jr_timestamp(Context context, ump::utility::jr_timestamp const &ts) {
+    details::call(jr_timestamp_, context, ts);
+  }
+  void delta_clockstamp_tpqn(Context context, ump::utility::delta_clockstamp_tpqn const &time) {
+    details::call(delta_clockstamp_tpqn_, context, time);
+  }
+  void delta_clockstamp(Context context, ump::utility::delta_clockstamp const &time) {
+    details::call(delta_clockstamp_, context, time);
+  }
+  void unknown(Context context, std::span<std::uint32_t> data) { details::call(unknown_, context, data); }
+
+private:
+  noop_fn noop_;
+  jr_clock_fn jr_clock_;
+  jr_timestamp_fn jr_timestamp_;
+  delta_clockstamp_tpqn_fn delta_clockstamp_tpqn_;
+  delta_clockstamp_fn delta_clockstamp_;
+  unknown_fn unknown_;
+};
+
+static_assert(utility<utility_fn<int>, int>);
+
+template <typename Context> class system_fn {
+public:
+  using midi_time_code_fn = std::function<void(Context, ump::system::midi_time_code const &)>;
+  using song_position_pointer_fn = std::function<void(Context, ump::system::song_position_pointer const &)>;
+  using song_select_fn = std::function<void(Context, ump::system::song_select const &)>;
+  using tune_request_fn = std::function<void(Context, ump::system::tune_request const &)>;
+  using timing_clock_fn = std::function<void(Context, ump::system::timing_clock const &)>;
+  using seq_start_fn = std::function<void(Context, ump::system::sequence_start const &)>;
+  using seq_continue_fn = std::function<void(Context, ump::system::sequence_continue const &)>;
+  using seq_stop_fn = std::function<void(Context, ump::system::sequence_stop const &)>;
+  using active_sensing_fn = std::function<void(Context, ump::system::active_sensing const &)>;
+  using reset_fn = std::function<void(Context, ump::system::reset const &)>;
+
+  constexpr system_fn &on_midi_time_code(midi_time_code_fn midi_time_code) {
+    midi_time_code_ = std::move(midi_time_code);
+    return *this;
+  }
+  constexpr system_fn &on_song_position_pointer(song_position_pointer_fn song_position_pointer) {
+    song_position_pointer_ = std::move(song_position_pointer);
+    return *this;
+  }
+  constexpr system_fn &on_song_select(song_select_fn song_select) {
+    song_select_ = std::move(song_select);
+    return *this;
+  }
+  constexpr system_fn &on_tune_request(tune_request_fn tune_request) {
+    tune_request_ = std::move(tune_request);
+    return *this;
+  }
+  constexpr system_fn &on_timing_clock(timing_clock_fn timing_clock) {
+    timing_clock_ = std::move(timing_clock);
+    return *this;
+  }
+  constexpr system_fn &on_seq_start(seq_start_fn seq_start) {
+    seq_start_ = std::move(seq_start);
+    return *this;
+  }
+  constexpr system_fn &on_seq_continue(seq_continue_fn seq_continue) {
+    seq_continue_ = std::move(seq_continue);
+    return *this;
+  }
+  constexpr system_fn &on_seq_stop(seq_stop_fn seq_stop) {
+    seq_stop_ = std::move(seq_stop);
+    return *this;
+  }
+  constexpr system_fn &on_active_sensing(active_sensing_fn active_sensing) {
+    active_sensing_ = std::move(active_sensing);
+    return *this;
+  }
+  constexpr system_fn &on_reset(reset_fn reset) {
+    reset_ = std::move(reset);
+    return *this;
+  }
+
+  // 7.6 System Common and System Real Time Messages
+  void midi_time_code(Context context, ump::system::midi_time_code const &mtc) {
+    details::call(midi_time_code_, context, mtc);
+  }
+  void song_position_pointer(Context context, ump::system::song_position_pointer const &spp) {
+    details::call(song_position_pointer_, context, spp);
+  }
+  void song_select(Context context, ump::system::song_select const &song) {
+    details::call(song_select_, context, song);
+  }
+  void tune_request(Context context, ump::system::tune_request const &request) {
+    details::call(tune_request_, context, request);
+  }
+  void timing_clock(Context context, ump::system::timing_clock const &clock) {
+    details::call(timing_clock_, context, clock);
+  }
+  void seq_start(Context context, ump::system::sequence_start const &ss) { details::call(seq_start_, context, ss); }
+  void seq_continue(Context context, ump::system::sequence_continue const &sc) {
+    details::call(seq_continue_, context, sc);
+  }
+  void seq_stop(Context context, ump::system::sequence_stop const &ss) { details::call(seq_stop_, context, ss); }
+  void active_sensing(Context context, ump::system::active_sensing const &as) {
+    details::call(active_sensing_, context, as);
+  }
+  void reset(Context context, ump::system::reset const &r) { details::call(reset_, context, r); }
+
+private:
+  midi_time_code_fn midi_time_code_;
+  song_position_pointer_fn song_position_pointer_;
+  song_select_fn song_select_;
+  tune_request_fn tune_request_;
+  timing_clock_fn timing_clock_;
+  seq_start_fn seq_start_;
+  seq_continue_fn seq_continue_;
+  seq_stop_fn seq_stop_;
+  active_sensing_fn active_sensing_;
+  reset_fn reset_;
+};
+
+static_assert(system<system_fn<int>, int>);
+
+template <typename Context> class m1cvm_fn {
+public:
+  using note_off_fn = std::function<void(Context, ump::m1cvm::note_off const &)>;
+  using note_on_fn = std::function<void(Context, ump::m1cvm::note_on const &)>;
+  using poly_pressure_fn = std::function<void(Context, ump::m1cvm::poly_pressure const &)>;
+  using control_change_fn = std::function<void(Context, ump::m1cvm::control_change const &)>;
+  using program_change_fn = std::function<void(Context, ump::m1cvm::program_change const &)>;
+  using channel_pressure_fn = std::function<void(Context, ump::m1cvm::channel_pressure const &)>;
+  using pitch_bend_fn = std::function<void(Context, ump::m1cvm::pitch_bend const &)>;
+
+  constexpr m1cvm_fn &on_note_off(note_off_fn note_off) noexcept {
+    note_off_ = std::move(note_off);
+    return *this;
+  }
+  constexpr m1cvm_fn &on_note_on(note_on_fn note_on) noexcept {
+    note_on_ = std::move(note_on);
+    return *this;
+  }
+  constexpr m1cvm_fn &on_poly_pressure(poly_pressure_fn poly_pressure) noexcept {
+    poly_pressure_ = std::move(poly_pressure);
+    return *this;
+  }
+  constexpr m1cvm_fn &on_control_change(control_change_fn control_change) noexcept {
+    control_change_ = std::move(control_change);
+    return *this;
+  }
+  constexpr m1cvm_fn &on_program_change(program_change_fn program_change) noexcept {
+    program_change_ = std::move(program_change);
+    return *this;
+  }
+  constexpr m1cvm_fn &on_channel_pressure(channel_pressure_fn channel_pressure) noexcept {
+    channel_pressure_ = std::move(channel_pressure);
+    return *this;
+  }
+  constexpr m1cvm_fn &on_pitch_bend(pitch_bend_fn pitch_bend) noexcept {
+    pitch_bend_ = std::move(pitch_bend);
+    return *this;
+  }
+
+  void note_off(Context context, ump::m1cvm::note_off const &noff) { details::call(note_off_, context, noff); }
+  void note_on(Context context, ump::m1cvm::note_on const &non) { details::call(note_on_, context, non); }
+  void poly_pressure(Context context, ump::m1cvm::poly_pressure const &pressure) {
+    details::call(poly_pressure_, context, pressure);
+  }
+  void control_change(Context context, ump::m1cvm::control_change const &cc) {
+    details::call(control_change_, context, cc);
+  }
+  void program_change(Context context, ump::m1cvm::program_change const &program) {
+    details::call(program_change_, context, program);
+  }
+  void channel_pressure(Context context, ump::m1cvm::channel_pressure const &pressure) {
+    details::call(channel_pressure_, context, pressure);
+  }
+  void pitch_bend(Context context, ump::m1cvm::pitch_bend const &bend) { details::call(pitch_bend_, context, bend); }
+
+private:
+  note_off_fn note_off_;
+  note_on_fn note_on_;
+  poly_pressure_fn poly_pressure_;
+  control_change_fn control_change_;
+  program_change_fn program_change_;
+  channel_pressure_fn channel_pressure_;
+  pitch_bend_fn pitch_bend_;
+};
+
+static_assert(m1cvm<m1cvm_fn<int>, int>);
+
+template <typename Context> class data64_fn {
+public:
+  using sysex7_in_1_fn = std::function<void(Context, ump::data64::sysex7_in_1 const &)>;
+  using sysex7_start_fn = std::function<void(Context, ump::data64::sysex7_start const &)>;
+  using sysex7_continue_fn = std::function<void(Context, ump::data64::sysex7_continue const &)>;
+  using sysex7_end_fn = std::function<void(Context, ump::data64::sysex7_end const &)>;
+
+  constexpr data64_fn &on_sysex7_in_1(sysex7_in_1_fn sysex7_in_1) noexcept {
+    sysex7_in_1_ = std::move(sysex7_in_1);
+    return *this;
+  }
+  constexpr data64_fn &on_sysex7_start(sysex7_start_fn sysex7_start) noexcept {
+    sysex7_start_ = std::move(sysex7_start);
+    return *this;
+  }
+  constexpr data64_fn &on_sysex7_continue(sysex7_continue_fn sysex7_continue) noexcept {
+    sysex7_continue_ = std::move(sysex7_continue);
+    return *this;
+  }
+  constexpr data64_fn &on_sysex7_end(sysex7_end_fn sysex7_end) noexcept {
+    sysex7_end_ = std::move(sysex7_end);
+    return *this;
+  }
+
+  void sysex7_in_1(Context context, ump::data64::sysex7_in_1 const &sx) { details::call(sysex7_in_1_, context, sx); }
+  void sysex7_start(Context context, ump::data64::sysex7_start const &sx) { details::call(sysex7_start_, context, sx); }
+  void sysex7_continue(Context context, ump::data64::sysex7_continue const &sx) {
+    details::call(sysex7_continue_, context, sx);
+  }
+  void sysex7_end(Context context, ump::data64::sysex7_end const &sx) { details::call(sysex7_end_, context, sx); }
+
+private:
+  sysex7_in_1_fn sysex7_in_1_;
+  sysex7_start_fn sysex7_start_;
+  sysex7_continue_fn sysex7_continue_;
+  sysex7_end_fn sysex7_end_;
+};
+
+static_assert(data64<data64_fn<int>, int>);
+
+template <typename Context> class m2cvm_fn {
+public:
+  using note_off_fn = std::function<void(Context, ump::m2cvm::note_off const &)>;
+  using note_on_fn = std::function<void(Context, ump::m2cvm::note_on const &)>;
+  using poly_pressure_fn = std::function<void(Context, ump::m2cvm::poly_pressure const &)>;
+  using program_change_fn = std::function<void(Context, ump::m2cvm::program_change const &)>;
+  using channel_pressure_fn = std::function<void(Context, ump::m2cvm::channel_pressure const &)>;
+  using rpn_per_note_controller_fn = std::function<void(Context, ump::m2cvm::rpn_per_note_controller const &)>;
+  using nrpn_per_note_controller_fn = std::function<void(Context, ump::m2cvm::nrpn_per_note_controller const &)>;
+  using rpn_controller_fn = std::function<void(Context, ump::m2cvm::rpn_controller const &)>;
+  using nrpn_controller_fn = std::function<void(Context, ump::m2cvm::nrpn_controller const &)>;
+  using rpn_relative_controller_fn = std::function<void(Context, ump::m2cvm::rpn_relative_controller const &)>;
+  using nrpn_relative_controller_fn = std::function<void(Context, ump::m2cvm::nrpn_relative_controller const &)>;
+  using per_note_management_fn = std::function<void(Context, ump::m2cvm::per_note_management const &)>;
+  using control_change_fn = std::function<void(Context, ump::m2cvm::control_change const &)>;
+  using pitch_bend_fn = std::function<void(Context, ump::m2cvm::pitch_bend const &)>;
+  using per_note_pitch_bend_fn = std::function<void(Context, ump::m2cvm::per_note_pitch_bend const &)>;
+
+  constexpr m2cvm_fn &on_note_off(note_off_fn noff) noexcept {
+    note_off_ = std::move(noff);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_note_on(note_on_fn non) noexcept {
+    note_on_ = std::move(non);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_poly_pressure(poly_pressure_fn pressure) noexcept {
+    poly_pressure_ = std::move(pressure);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_program_change(program_change_fn program_change) noexcept {
+    program_change_ = std::move(program_change);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_channel_pressure(channel_pressure_fn pressure) noexcept {
+    channel_pressure_ = std::move(pressure);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_rpn_per_note_controller(rpn_per_note_controller_fn controller) noexcept {
+    rpn_per_note_controller_ = std::move(controller);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_nrpn_per_note_controller(nrpn_per_note_controller_fn controller) noexcept {
+    nrpn_per_note_controller_ = std::move(controller);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_rpn_controller(rpn_controller_fn controller) noexcept {
+    rpn_controller_ = std::move(controller);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_nrpn_controller(nrpn_controller_fn controller) noexcept {
+    nrpn_controller_ = std::move(controller);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_rpn_relative_controller(rpn_relative_controller_fn controller) noexcept {
+    rpn_relative_controller_ = std::move(controller);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_nrpn_relative_controller(nrpn_relative_controller_fn controller) noexcept {
+    nrpn_relative_controller_ = std::move(controller);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_per_note_management(per_note_management_fn per_note_management) noexcept {
+    per_note_management_ = std::move(per_note_management);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_control_change(control_change_fn cc) noexcept {
+    control_change_ = std::move(cc);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_pitch_bend(pitch_bend_fn pitch_bend) noexcept {
+    pitch_bend_ = std::move(pitch_bend);
+    return *this;
+  }
+  constexpr m2cvm_fn &on_per_note_pitch_bend(per_note_pitch_bend_fn per_note_pitch_bend) noexcept {
+    per_note_pitch_bend_ = std::move(per_note_pitch_bend);
+    return *this;
+  }
+
+  void note_off(Context context, ump::m2cvm::note_off const &noff) { details::call(note_off_, context, noff); }
+  void note_on(Context context, ump::m2cvm::note_on const &non) { details::call(note_on_, context, non); }
+  void poly_pressure(Context context, ump::m2cvm::poly_pressure const &pressure) {
+    details::call(poly_pressure_, context, pressure);
+  }
+  void program_change(Context context, ump::m2cvm::program_change const &program) {
+    details::call(program_change_, context, program);
+  }
+  void channel_pressure(Context context, ump::m2cvm::channel_pressure const &pressure) {
+    details::call(channel_pressure_, context, pressure);
+  }
+  void rpn_per_note_controller(Context context, ump::m2cvm::rpn_per_note_controller const &rpn) {
+    details::call(rpn_per_note_controller_, context, rpn);
+  }
+  void nrpn_per_note_controller(Context context, ump::m2cvm::nrpn_per_note_controller const &nrpn) {
+    details::call(nrpn_per_note_controller_, context, nrpn);
+  }
+  void rpn_controller(Context context, ump::m2cvm::rpn_controller const &rpn) {
+    details::call(rpn_controller_, context, rpn);
+  }
+  void nrpn_controller(Context context, ump::m2cvm::nrpn_controller const &nrpn) {
+    details::call(nrpn_controller_, context, nrpn);
+  }
+  void rpn_relative_controller(Context context, ump::m2cvm::rpn_relative_controller const &rpn) {
+    details::call(rpn_relative_controller_, context, rpn);
+  }
+  void nrpn_relative_controller(Context context, ump::m2cvm::nrpn_relative_controller const &nrpn) {
+    details::call(nrpn_relative_controller_, context, nrpn);
+  }
+  void per_note_management(Context context, ump::m2cvm::per_note_management const &pnm) {
+    details::call(per_note_management_, context, pnm);
+  }
+  void control_change(Context context, ump::m2cvm::control_change const &cc) {
+    details::call(control_change_, context, cc);
+  }
+  void pitch_bend(Context context, ump::m2cvm::pitch_bend const &pb) { details::call(pitch_bend_, context, pb); }
+  void per_note_pitch_bend(Context context, ump::m2cvm::per_note_pitch_bend const &pb) {
+    details::call(per_note_pitch_bend_, context, pb);
+  }
+
+private:
+  note_off_fn note_off_;
+  note_on_fn note_on_;
+  poly_pressure_fn poly_pressure_;
+  program_change_fn program_change_;
+  channel_pressure_fn channel_pressure_;
+  rpn_per_note_controller_fn rpn_per_note_controller_;
+  nrpn_per_note_controller_fn nrpn_per_note_controller_;
+  rpn_controller_fn rpn_controller_;
+  nrpn_controller_fn nrpn_controller_;
+  rpn_relative_controller_fn rpn_relative_controller_;
+  nrpn_relative_controller_fn nrpn_relative_controller_;
+  per_note_management_fn per_note_management_;
+  control_change_fn control_change_;
+  pitch_bend_fn pitch_bend_;
+  per_note_pitch_bend_fn per_note_pitch_bend_;
+};
+
+static_assert(m2cvm<m2cvm_fn<int>, int>);
+
+template <typename Context> class data128_fn {
+public:
+  using sysex8_in_1_fn = std::function<void(Context, ump::data128::sysex8_in_1 const &)>;
+  using sysex8_start_fn = std::function<void(Context, ump::data128::sysex8_start const &)>;
+  using sysex8_continue_fn = std::function<void(Context, ump::data128::sysex8_continue const &)>;
+  using sysex8_end_fn = std::function<void(Context, ump::data128::sysex8_end const &)>;
+  using mds_header_fn = std::function<void(Context, ump::data128::mds_header const &)>;
+  using mds_payload_fn = std::function<void(Context, ump::data128::mds_payload const &)>;
+
+  constexpr data128_fn &on_sysex8_in_1(sysex8_in_1_fn sysex8_in_1) noexcept {
+    sysex8_in_1_ = std::move(sysex8_in_1);
+    return *this;
+  }
+  constexpr data128_fn &on_sysex8_start(sysex8_start_fn sysex8_start) noexcept {
+    sysex8_start_ = std::move(sysex8_start);
+    return *this;
+  }
+  constexpr data128_fn &on_sysex8_continue(sysex8_continue_fn sysex8_continue) noexcept {
+    sysex8_continue_ = std::move(sysex8_continue);
+    return *this;
+  }
+  constexpr data128_fn &on_sysex8_end(sysex8_end_fn sysex8_end) noexcept {
+    sysex8_end_ = std::move(sysex8_end);
+    return *this;
+  }
+  constexpr data128_fn &on_mds_header(mds_header_fn mds_header) noexcept {
+    mds_header_ = std::move(mds_header);
+    return *this;
+  }
+  constexpr data128_fn &on_mds_payload(mds_payload_fn mds_payload) noexcept {
+    mds_payload_ = std::move(mds_payload);
+    return *this;
+  }
+
+  void sysex8_in_1(Context context, ump::data128::sysex8_in_1 const &sysex) {
+    details::call(sysex8_in_1_, context, sysex);
+  }
+  void sysex8_start(Context context, ump::data128::sysex8_start const &sysex) {
+    details::call(sysex8_start_, context, sysex);
+  }
+  void sysex8_continue(Context context, ump::data128::sysex8_continue const &sysex) {
+    details::call(sysex8_continue_, context, sysex);
+  }
+  void sysex8_end(Context context, ump::data128::sysex8_end const &sysex) {
+    details::call(sysex8_end_, context, sysex);
+  }
+  void mds_header(Context context, ump::data128::mds_header const &mds) { details::call(mds_header_, context, mds); }
+  void mds_payload(Context context, ump::data128::mds_payload const &mds) { details::call(mds_payload_, context, mds); }
+
+private:
+  sysex8_in_1_fn sysex8_in_1_;
+  sysex8_start_fn sysex8_start_;
+  sysex8_continue_fn sysex8_continue_;
+  sysex8_end_fn sysex8_end_;
+  mds_header_fn mds_header_;
+  mds_payload_fn mds_payload_;
+};
+
+static_assert(data128<data128_fn<int>, int>);
+
+template <typename Context> class ump_stream_fn {
+public:
+  using endpoint_discovery_fn = std::function<void(Context, ump::ump_stream::endpoint_discovery const &)>;
+  using endpoint_info_notification_fn =
+      std::function<void(Context, ump::ump_stream::endpoint_info_notification const &)>;
+  using device_identity_notification_fn =
+      std::function<void(Context, ump::ump_stream::device_identity_notification const &)>;
+  using endpoint_name_notification_fn =
+      std::function<void(Context, ump::ump_stream::endpoint_name_notification const &)>;
+  using product_instance_id_notification_fn =
+      std::function<void(Context, ump::ump_stream::product_instance_id_notification const &)>;
+  using jr_configuration_request_fn = std::function<void(Context, ump::ump_stream::jr_configuration_request const &)>;
+  using jr_configuration_notification_fn =
+      std::function<void(Context, ump::ump_stream::jr_configuration_notification const &)>;
+  using function_block_discovery_fn = std::function<void(Context, ump::ump_stream::function_block_discovery const &)>;
+  using function_block_info_notification_fn =
+      std::function<void(Context, ump::ump_stream::function_block_info_notification const &)>;
+  using function_block_name_notification_fn =
+      std::function<void(Context, ump::ump_stream::function_block_name_notification const &)>;
+  using start_of_clip_fn = std::function<void(Context, ump::ump_stream::start_of_clip const &)>;
+  using end_of_clip_fn = std::function<void(Context, ump::ump_stream::end_of_clip const &)>;
+
+  constexpr ump_stream_fn &on_endpoint_discovery(endpoint_discovery_fn discovery) noexcept {
+    endpoint_discovery_ = std::move(discovery);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_endpoint_info_notification(endpoint_info_notification_fn notification) noexcept {
+    endpoint_info_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_device_identity_notification(device_identity_notification_fn notification) noexcept {
+    device_identity_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_endpoint_name_notification(endpoint_name_notification_fn notification) noexcept {
+    endpoint_name_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_product_instance_id_notification(
+      product_instance_id_notification_fn notification) noexcept {
+    product_instance_id_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_jr_configuration_request(jr_configuration_request_fn request) noexcept {
+    jr_configuration_request_ = std::move(request);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_jr_configuration_notification(jr_configuration_notification_fn notification) noexcept {
+    jr_configuration_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_function_block_discovery(function_block_discovery_fn discovery) noexcept {
+    function_block_discovery_ = std::move(discovery);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_function_block_info_notification(
+      function_block_info_notification_fn notification) noexcept {
+    function_block_info_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_function_block_name_notification(
+      function_block_name_notification_fn notification) noexcept {
+    function_block_name_notification_ = std::move(notification);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_start_of_clip(start_of_clip_fn clip) noexcept {
+    start_of_clip_ = std::move(clip);
+    return *this;
+  }
+  constexpr ump_stream_fn &on_end_of_clip(end_of_clip_fn clip) noexcept {
+    end_of_clip_ = std::move(clip);
+    return *this;
+  }
+
+  void endpoint_discovery(Context context, ump::ump_stream::endpoint_discovery const &discovery) {
+    details::call(endpoint_discovery_, context, discovery);
+  }
+  void endpoint_info_notification(Context context, ump::ump_stream::endpoint_info_notification const &notification) {
+    details::call(endpoint_info_notification_, context, notification);
+  }
+  void device_identity_notification(Context context,
+                                    ump::ump_stream::device_identity_notification const &notification) {
+    details::call(device_identity_notification_, context, notification);
+  }
+  void endpoint_name_notification(Context context, ump::ump_stream::endpoint_name_notification const &notification) {
+    details::call(endpoint_name_notification_, context, notification);
+  }
+  void product_instance_id_notification(Context context,
+                                        ump::ump_stream::product_instance_id_notification const &notification) {
+    details::call(product_instance_id_notification_, context, notification);
+  }
+  void jr_configuration_request(Context context, ump::ump_stream::jr_configuration_request const &request) {
+    details::call(jr_configuration_request_, context, request);
+  }
+  void jr_configuration_notification(Context context,
+                                     ump::ump_stream::jr_configuration_notification const &notification) {
+    details::call(jr_configuration_notification_, context, notification);
+  }
+  void function_block_discovery(Context context, ump::ump_stream::function_block_discovery const &discovery) {
+    details::call(function_block_discovery_, context, discovery);
+  }
+  void function_block_info_notification(Context context,
+                                        ump::ump_stream::function_block_info_notification const &notification) {
+    details::call(function_block_info_notification_, context, notification);
+  }
+  void function_block_name_notification(Context context,
+                                        ump::ump_stream::function_block_name_notification const &notification) {
+    details::call(function_block_name_notification_, context, notification);
+  }
+  void start_of_clip(Context context, ump::ump_stream::start_of_clip const &clip) {
+    details::call(start_of_clip_, context, clip);
+  }
+  void end_of_clip(Context context, ump::ump_stream::end_of_clip const &clip) {
+    details::call(end_of_clip_, context, clip);
+  }
+
+private:
+  endpoint_discovery_fn endpoint_discovery_;
+  endpoint_info_notification_fn endpoint_info_notification_;
+  device_identity_notification_fn device_identity_notification_;
+  endpoint_name_notification_fn endpoint_name_notification_;
+  product_instance_id_notification_fn product_instance_id_notification_;
+  jr_configuration_request_fn jr_configuration_request_;
+  jr_configuration_notification_fn jr_configuration_notification_;
+
+  function_block_discovery_fn function_block_discovery_;
+  function_block_info_notification_fn function_block_info_notification_;
+  function_block_name_notification_fn function_block_name_notification_;
+
+  start_of_clip_fn start_of_clip_;
+  end_of_clip_fn end_of_clip_;
+};
+
+static_assert(ump_stream<ump_stream_fn<int>, int>);
+
+template <typename Context> class flex_data_fn {
+public:
+  using set_tempo_fn = std::function<void(Context, ump::flex_data::set_tempo const &)>;
+  using set_time_signature_fn = std::function<void(Context, ump::flex_data::set_time_signature const &)>;
+  using set_metronome_fn = std::function<void(Context, ump::flex_data::set_metronome const &)>;
+  using set_key_signature_fn = std::function<void(Context, ump::flex_data::set_key_signature const &)>;
+  using set_chord_name_fn = std::function<void(Context, ump::flex_data::set_chord_name const &)>;
+  using text_fn = std::function<void(Context, ump::flex_data::text_common const &)>;
+
+  constexpr flex_data_fn &on_set_tempo(set_tempo_fn set_tempo) noexcept {
+    set_tempo_ = std::move(set_tempo);
+    return *this;
+  }
+  constexpr flex_data_fn &on_set_time_signature(set_time_signature_fn set_time_signature) noexcept {
+    set_time_signature_ = std::move(set_time_signature);
+    return *this;
+  }
+  constexpr flex_data_fn &on_set_metronome(set_metronome_fn set_metronome) noexcept {
+    set_metronome_ = std::move(set_metronome);
+    return *this;
+  }
+  constexpr flex_data_fn &on_set_key_signature(set_key_signature_fn set_key_signature) noexcept {
+    set_key_signature_ = std::move(set_key_signature);
+    return *this;
+  }
+  constexpr flex_data_fn &on_set_chord_name(set_chord_name_fn set_chord_name) noexcept {
+    set_chord_name_ = std::move(set_chord_name);
+    return *this;
+  }
+  constexpr flex_data_fn &on_text(text_fn text) noexcept {
+    text_ = std::move(text);
+    return *this;
+  }
+
+  void set_tempo(Context context, ump::flex_data::set_tempo const &tempo) { details::call(set_tempo_, context, tempo); }
+  void set_time_signature(Context context, ump::flex_data::set_time_signature const &ts) {
+    details::call(set_time_signature_, context, ts);
+  }
+  void set_metronome(Context context, ump::flex_data::set_metronome const &metronome) {
+    details::call(set_metronome_, context, metronome);
+  }
+  void set_key_signature(Context context, ump::flex_data::set_key_signature const &ks) {
+    details::call(set_key_signature_, context, ks);
+  }
+  void set_chord_name(Context context, ump::flex_data::set_chord_name const &chord) {
+    details::call(set_chord_name_, context, chord);
+  }
+  void text(Context context, ump::flex_data::text_common const &t) { details::call(text_, context, t); }
+
+private:
+  set_tempo_fn set_tempo_;
+  set_time_signature_fn set_time_signature_;
+  set_metronome_fn set_metronome_;
+  set_key_signature_fn set_key_signature_;
+  set_chord_name_fn set_chord_name_;
+  text_fn text_;
+};
+
+static_assert(flex_data<flex_data_fn<int>, int>);
+
+}  // end namespace midi2::dispatcher_backend
+
+#endif  // MIDI2_DISPATCHER_BACKEND_HPP

--- a/include/midi2/ump_to_bytestream.hpp
+++ b/include/midi2/ump_to_bytestream.hpp
@@ -287,9 +287,9 @@ private:
     };
     context_type *context = nullptr;
     [[no_unique_address]] utility_null<decltype(context)> utility{};
-    [[no_unique_address]] struct system system{};
-    [[no_unique_address]] struct m1cvm m1cvm{};
-    [[no_unique_address]] struct data64 data64{};
+    [[no_unique_address]] class system system{};
+    [[no_unique_address]] class m1cvm m1cvm{};
+    [[no_unique_address]] class data64 data64{};
     [[no_unique_address]] m2cvm_null<decltype(context)> m2cvm{};
     [[no_unique_address]] data128_null<decltype(context)> data128{};
     [[no_unique_address]] ump_stream_null<decltype(context)> ump_stream{};

--- a/include/midi2/ump_to_bytestream.hpp
+++ b/include/midi2/ump_to_bytestream.hpp
@@ -286,14 +286,14 @@ private:
       }
     };
     context_type *context = nullptr;
-    [[no_unique_address]] utility_null<decltype(context)> utility{};
+    [[no_unique_address]] dispatcher_backend::utility_null<decltype(context)> utility{};
     [[no_unique_address]] class system system{};
     [[no_unique_address]] class m1cvm m1cvm{};
     [[no_unique_address]] class data64 data64{};
-    [[no_unique_address]] m2cvm_null<decltype(context)> m2cvm{};
-    [[no_unique_address]] data128_null<decltype(context)> data128{};
-    [[no_unique_address]] ump_stream_null<decltype(context)> ump_stream{};
-    [[no_unique_address]] flex_data_null<decltype(context)> flex{};
+    [[no_unique_address]] dispatcher_backend::m2cvm_null<decltype(context)> m2cvm{};
+    [[no_unique_address]] dispatcher_backend::data128_null<decltype(context)> data128{};
+    [[no_unique_address]] dispatcher_backend::ump_stream_null<decltype(context)> ump_stream{};
+    [[no_unique_address]] dispatcher_backend::flex_data_null<decltype(context)> flex{};
   };
   context_type context_;
   ump_dispatcher<to_bytestream_config> p_{to_bytestream_config{.context = &context_}};

--- a/include/midi2/ump_to_midi1.hpp
+++ b/include/midi2/ump_to_midi1.hpp
@@ -162,14 +162,14 @@ private:
                              std::pair<std::uint8_t, std::uint8_t> const &controller_number, std::uint32_t value);
     };
     context_type *context = nullptr;
-    [[no_unique_address]] utility_null<decltype(context)> utility{};
+    [[no_unique_address]] dispatcher_backend::utility_null<decltype(context)> utility{};
     [[no_unique_address]] struct system system{};
     [[no_unique_address]] struct m1cvm m1cvm{};
     [[no_unique_address]] struct data64 data64{};
     [[no_unique_address]] class m2cvm m2cvm{};
-    [[no_unique_address]] data128_null<decltype(context)> data128{};
-    [[no_unique_address]] ump_stream_null<decltype(context)> ump_stream{};
-    [[no_unique_address]] flex_data_null<decltype(context)> flex{};
+    [[no_unique_address]] dispatcher_backend::data128_null<decltype(context)> data128{};
+    [[no_unique_address]] dispatcher_backend::ump_stream_null<decltype(context)> ump_stream{};
+    [[no_unique_address]] dispatcher_backend::flex_data_null<decltype(context)> flex{};
   };
   context_type context_;
   ump_dispatcher<to_midi1_config> p_{to_midi1_config{&context_}};

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable (m2unittests
   test_ci_create_message.cpp
   test_ci_dispatcher.cpp
   test_ci_types.cpp
+  test_dispatcher_backend.cpp
   test_fifo.cpp
   test_iumap.cpp
   test_lru.cpp
@@ -48,5 +49,4 @@ else ()
 endif (MIDI2_FUZZTEST)
 
 include(GoogleTest)
-gtest_discover_tests(m2unittests)
-       
+gtest_discover_tests(m2unittests DISCOVERY_MODE PRE_TEST)

--- a/unittests/test_dispatcher_backend.cpp
+++ b/unittests/test_dispatcher_backend.cpp
@@ -1,0 +1,736 @@
+//===-- UMP Dispatcher Backends -----------------------------------------------*- C++ -*-===//
+//
+// midi2 library under the MIT license.
+// See https://github.com/paulhuggett/AM_MIDI2.0Lib/blob/main/LICENSE for license information.
+// SPDX-License-Identifier: MIT
+//
+//===------------------------------------------------------------------------------------===//
+#include "midi2/dispatcher_backend.hpp"
+
+#include <gmock/gmock.h>
+
+namespace {
+
+struct context_type {
+  constexpr bool operator==(context_type const &) const noexcept = default;
+  int value = 23;
+};
+
+using testing::ElementsAreArray;
+using testing::InSequence;
+using testing::MockFunction;
+using testing::StrictMock;
+
+constexpr std::uint32_t operator""_u32(unsigned long long v) {
+  assert(v <= std::numeric_limits<std::uint32_t>::max());
+  return static_cast<std::uint32_t>(v);
+}
+
+class DispatcherBackendUtility : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::utility_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, Noop) {
+  StrictMock<MockFunction<decltype(be_)::noop_fn>> fn;
+  // The first call should do nothing since no handler has been installed.
+  be_.noop(context_);
+  // Install a handler for the noop message.
+  be_.on_noop(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  EXPECT_CALL(fn, Call(context_)).Times(1);
+  be_.noop(context_);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, JrClock) {
+  StrictMock<MockFunction<decltype(be_)::jr_clock_fn>> fn;
+  midi2::ump::utility::jr_clock clock;
+  be_.jr_clock(context_, clock);
+  be_.on_jr_clock(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, clock)).Times(1);
+  be_.jr_clock(context_, clock);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, JrTimestamp) {
+  StrictMock<MockFunction<decltype(be_)::jr_timestamp_fn>> fn;
+  midi2::ump::utility::jr_timestamp time_stamp;
+  be_.jr_timestamp(context_, time_stamp);
+  be_.on_jr_timestamp(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, time_stamp)).Times(1);
+  be_.jr_timestamp(context_, time_stamp);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, DeltaClockstampTPQN) {
+  StrictMock<MockFunction<decltype(be_)::delta_clockstamp_tpqn_fn>> fn;
+  midi2::ump::utility::delta_clockstamp_tpqn delta_clockstamp;
+  be_.delta_clockstamp_tpqn(context_, delta_clockstamp);
+  be_.on_delta_clockstamp_tpqn(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, delta_clockstamp)).Times(1);
+  be_.delta_clockstamp_tpqn(context_, delta_clockstamp);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, DeltaClockstamp) {
+  StrictMock<MockFunction<decltype(be_)::delta_clockstamp_fn>> fn;
+  midi2::ump::utility::delta_clockstamp delta_clockstamp;
+  be_.delta_clockstamp(context_, delta_clockstamp);
+  be_.on_delta_clockstamp(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, delta_clockstamp)).Times(1);
+  be_.delta_clockstamp(context_, delta_clockstamp);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, Unknown) {
+  StrictMock<MockFunction<decltype(be_)::unknown_fn>> fn;
+  std::array message{0xFFFFFFFF_u32, 0xFFFFFFFE_u32, 0xFFFFFFFD_u32, 0xFFFFFFFC_u32, 0xFFFFFFFB_u32};
+  be_.unknown(context_, std::span{message});
+  be_.on_unknown(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, ElementsAreArray(message))).Times(1);
+  be_.unknown(context_, std::span{message});
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendUtility, Chained) {
+  StrictMock<MockFunction<decltype(be_)::noop_fn>> noop;
+  StrictMock<MockFunction<decltype(be_)::jr_clock_fn>> jrc;
+  InSequence _;
+  midi2::ump::utility::jr_clock clock;
+  EXPECT_CALL(noop, Call(context_)).Times(1);
+  EXPECT_CALL(jrc, Call(context_, clock)).Times(1);
+  // Chained calls to the functions setting the message handlers.
+  be_.on_noop(noop.AsStdFunction()).on_jr_clock(jrc.AsStdFunction());
+
+  be_.noop(context_);
+  be_.jr_clock(context_, clock);
+}
+
+class DispatcherBackendSystem : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::system_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, MidiTimeCode) {
+  StrictMock<MockFunction<decltype(be_)::midi_time_code_fn>> fn;
+  midi2::ump::system::midi_time_code mtc;
+  // The first call should do nothing since no handler has been installed.
+  be_.midi_time_code(context_, mtc);
+  // Install a handler for the noop message.
+  be_.on_midi_time_code(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  EXPECT_CALL(fn, Call(context_, mtc)).Times(1);
+  be_.midi_time_code(context_, mtc);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, SongPositionPointer) {
+  StrictMock<MockFunction<decltype(be_)::song_position_pointer_fn>> fn;
+  midi2::ump::system::song_position_pointer spp;
+  be_.song_position_pointer(context_, spp);
+  be_.on_song_position_pointer(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, spp)).Times(1);
+  be_.song_position_pointer(context_, spp);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, SongSelect) {
+  StrictMock<MockFunction<decltype(be_)::song_select_fn>> fn;
+  midi2::ump::system::song_select ss;
+  be_.song_select(context_, ss);
+  be_.on_song_select(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, ss)).Times(1);
+  be_.song_select(context_, ss);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, TuneRequest) {
+  StrictMock<MockFunction<decltype(be_)::tune_request_fn>> fn;
+  midi2::ump::system::tune_request tr;
+  be_.tune_request(context_, tr);
+  be_.on_tune_request(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, tr)).Times(1);
+  be_.tune_request(context_, tr);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, TimingClock) {
+  StrictMock<MockFunction<decltype(be_)::timing_clock_fn>> fn;
+  midi2::ump::system::timing_clock clock;
+  be_.timing_clock(context_, clock);
+  be_.on_timing_clock(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, clock)).Times(1);
+  be_.timing_clock(context_, clock);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, SequenceStart) {
+  StrictMock<MockFunction<decltype(be_)::seq_start_fn>> fn;
+  midi2::ump::system::sequence_start ss;
+  be_.seq_start(context_, ss);
+  be_.on_seq_start(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, ss)).Times(1);
+  be_.seq_start(context_, ss);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, SequenceContinue) {
+  StrictMock<MockFunction<decltype(be_)::seq_continue_fn>> fn;
+  midi2::ump::system::sequence_continue sc;
+  be_.seq_continue(context_, sc);
+  be_.on_seq_continue(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, sc)).Times(1);
+  be_.seq_continue(context_, sc);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, SequenceStop) {
+  StrictMock<MockFunction<decltype(be_)::seq_stop_fn>> fn;
+  midi2::ump::system::sequence_stop ss;
+  be_.seq_stop(context_, ss);
+  be_.on_seq_stop(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, ss)).Times(1);
+  be_.seq_stop(context_, ss);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, ActiveSensing) {
+  StrictMock<MockFunction<decltype(be_)::active_sensing_fn>> fn;
+  midi2::ump::system::active_sensing as;
+  be_.active_sensing(context_, as);
+  be_.on_active_sensing(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, as)).Times(1);
+  be_.active_sensing(context_, as);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendSystem, Reset) {
+  StrictMock<MockFunction<decltype(be_)::reset_fn>> fn;
+  midi2::ump::system::reset r;
+  be_.reset(context_, r);
+  be_.on_reset(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, r)).Times(1);
+  be_.reset(context_, r);
+}
+
+class DispatcherBackendM1CVM : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::m1cvm_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, NoteOff) {
+  StrictMock<MockFunction<decltype(be_)::note_off_fn>> fn;
+  midi2::ump::m1cvm::note_off noff;
+  // The first call should do nothing since no handler has been installed.
+  be_.note_off(context_, noff);
+  // Install a handler for the noop message.
+  be_.on_note_off(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  EXPECT_CALL(fn, Call(context_, noff)).Times(1);
+  be_.note_off(context_, noff);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, NoteOn) {
+  StrictMock<MockFunction<decltype(be_)::note_on_fn>> fn;
+  midi2::ump::m1cvm::note_on non;
+  be_.note_on(context_, non);
+  be_.on_note_on(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, non)).Times(1);
+  be_.note_on(context_, non);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, PolyPressure) {
+  StrictMock<MockFunction<decltype(be_)::poly_pressure_fn>> fn;
+  midi2::ump::m1cvm::poly_pressure pressure;
+  be_.poly_pressure(context_, pressure);
+  be_.on_poly_pressure(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, pressure)).Times(1);
+  be_.poly_pressure(context_, pressure);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, ControlChange) {
+  StrictMock<MockFunction<decltype(be_)::control_change_fn>> fn;
+  midi2::ump::m1cvm::control_change cc;
+  be_.control_change(context_, cc);
+  be_.on_control_change(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, cc)).Times(1);
+  be_.control_change(context_, cc);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, ProgramChange) {
+  StrictMock<MockFunction<decltype(be_)::program_change_fn>> fn;
+  midi2::ump::m1cvm::program_change pc;
+  be_.program_change(context_, pc);
+  be_.on_program_change(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, pc)).Times(1);
+  be_.program_change(context_, pc);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, ChannelPressure) {
+  StrictMock<MockFunction<decltype(be_)::channel_pressure_fn>> fn;
+  midi2::ump::m1cvm::channel_pressure pressure;
+  be_.channel_pressure(context_, pressure);
+  be_.on_channel_pressure(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, pressure)).Times(1);
+  be_.channel_pressure(context_, pressure);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM1CVM, PitchBend) {
+  StrictMock<MockFunction<decltype(be_)::pitch_bend_fn>> fn;
+  midi2::ump::m1cvm::pitch_bend pb;
+  be_.pitch_bend(context_, pb);
+  be_.on_pitch_bend(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, pb)).Times(1);
+  be_.pitch_bend(context_, pb);
+}
+
+class DispatcherBackendData64 : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::data64_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData64, Sysex7In1) {
+  StrictMock<MockFunction<decltype(be_)::sysex7_in_1_fn>> fn;
+  midi2::ump::data64::sysex7_in_1 sx;
+  // The first call should do nothing since no handler has been installed.
+  be_.sysex7_in_1(context_, sx);
+  // Install a handler for the noop message.
+  be_.on_sysex7_in_1(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.sysex7_in_1(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData64, Sysex7Start) {
+  StrictMock<MockFunction<decltype(be_)::sysex7_start_fn>> fn;
+  midi2::ump::data64::sysex7_start sx;
+  be_.sysex7_start(context_, sx);
+  be_.on_sysex7_start(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.sysex7_start(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData64, Sysex7Continue) {
+  StrictMock<MockFunction<decltype(be_)::sysex7_continue_fn>> fn;
+  midi2::ump::data64::sysex7_continue sx;
+  be_.sysex7_continue(context_, sx);
+  be_.on_sysex7_continue(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.sysex7_continue(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData64, Sysex7End) {
+  StrictMock<MockFunction<decltype(be_)::sysex7_end_fn>> fn;
+  midi2::ump::data64::sysex7_end sx;
+  be_.sysex7_end(context_, sx);
+  be_.on_sysex7_end(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.sysex7_end(context_, sx);
+}
+
+class DispatcherBackendM2CVM : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::m2cvm_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, NoteOff) {
+  StrictMock<MockFunction<decltype(be_)::note_off_fn>> fn;
+  midi2::ump::m2cvm::note_off noff;
+  // The first call should do nothing since no handler has been installed.
+  be_.note_off(context_, noff);
+  // Install a handler for the noop message.
+  be_.on_note_off(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  EXPECT_CALL(fn, Call(context_, noff)).Times(1);
+  be_.note_off(context_, noff);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, NoteOn) {
+  StrictMock<MockFunction<decltype(be_)::note_on_fn>> fn;
+  midi2::ump::m2cvm::note_on non;
+  be_.note_on(context_, non);
+  be_.on_note_on(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, non)).Times(1);
+  be_.note_on(context_, non);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, PolyPressure) {
+  StrictMock<MockFunction<decltype(be_)::poly_pressure_fn>> fn;
+  midi2::ump::m2cvm::poly_pressure pressure;
+  be_.poly_pressure(context_, pressure);
+  be_.on_poly_pressure(fn.AsStdFunction());
+  EXPECT_CALL(fn, Call(context_, pressure)).Times(1);
+  be_.poly_pressure(context_, pressure);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, ProgramChange) {
+  midi2::ump::m2cvm::program_change pc;
+  be_.program_change(context_, pc);
+
+  StrictMock<MockFunction<decltype(be_)::program_change_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, pc)).Times(1);
+  be_.on_program_change(fn.AsStdFunction());
+  be_.program_change(context_, pc);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, ChannelPressure) {
+  midi2::ump::m2cvm::channel_pressure pressure;
+  be_.channel_pressure(context_, pressure);
+
+  StrictMock<MockFunction<decltype(be_)::channel_pressure_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, pressure)).Times(1);
+  be_.on_channel_pressure(fn.AsStdFunction());
+  be_.channel_pressure(context_, pressure);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, RPNPerNoteController) {
+  midi2::ump::m2cvm::rpn_per_note_controller rpn;
+  be_.rpn_per_note_controller(context_, rpn);
+
+  StrictMock<MockFunction<decltype(be_)::rpn_per_note_controller_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, rpn)).Times(1);
+  be_.on_rpn_per_note_controller(fn.AsStdFunction());
+  be_.rpn_per_note_controller(context_, rpn);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, NRPNPerNoteController) {
+  midi2::ump::m2cvm::nrpn_per_note_controller nrpn;
+  be_.nrpn_per_note_controller(context_, nrpn);
+
+  StrictMock<MockFunction<decltype(be_)::nrpn_per_note_controller_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, nrpn)).Times(1);
+  be_.on_nrpn_per_note_controller(fn.AsStdFunction());
+  be_.nrpn_per_note_controller(context_, nrpn);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, RPNController) {
+  midi2::ump::m2cvm::rpn_controller rpn;
+  be_.rpn_controller(context_, rpn);
+
+  StrictMock<MockFunction<decltype(be_)::rpn_controller_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, rpn)).Times(1);
+  be_.on_rpn_controller(fn.AsStdFunction());
+  be_.rpn_controller(context_, rpn);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, NRPNController) {
+  midi2::ump::m2cvm::nrpn_controller nrpn;
+  be_.nrpn_controller(context_, nrpn);
+
+  StrictMock<MockFunction<decltype(be_)::nrpn_controller_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, nrpn)).Times(1);
+  be_.on_nrpn_controller(fn.AsStdFunction());
+  be_.nrpn_controller(context_, nrpn);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, RPNRelativeController) {
+  midi2::ump::m2cvm::rpn_relative_controller message;
+  be_.rpn_relative_controller(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::rpn_relative_controller_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_rpn_relative_controller(fn.AsStdFunction());
+  be_.rpn_relative_controller(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, NRPNRelativeController) {
+  midi2::ump::m2cvm::nrpn_relative_controller message;
+  be_.nrpn_relative_controller(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::nrpn_relative_controller_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_nrpn_relative_controller(fn.AsStdFunction());
+  be_.nrpn_relative_controller(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, PerNoteManagement) {
+  midi2::ump::m2cvm::per_note_management message;
+  be_.per_note_management(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::per_note_management_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_per_note_management(fn.AsStdFunction());
+  be_.per_note_management(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, ControlChange) {
+  midi2::ump::m2cvm::control_change message;
+  be_.control_change(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::control_change_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_control_change(fn.AsStdFunction());
+  be_.control_change(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, PitchBend) {
+  midi2::ump::m2cvm::pitch_bend message;
+  be_.pitch_bend(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::pitch_bend_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_pitch_bend(fn.AsStdFunction());
+  be_.pitch_bend(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendM2CVM, PerNotePitchBend) {
+  midi2::ump::m2cvm::per_note_pitch_bend message;
+  be_.per_note_pitch_bend(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::per_note_pitch_bend_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_per_note_pitch_bend(fn.AsStdFunction());
+  be_.per_note_pitch_bend(context_, message);
+}
+
+class DispatcherBackendData128 : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::data128_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData128, SysEx8In1) {
+  midi2::ump::data128::sysex8_in_1 sx;
+  // The first call should do nothing since no handler has been installed.
+  be_.sysex8_in_1(context_, sx);
+  // Install a handler for the noop message.
+  StrictMock<MockFunction<decltype(be_)::sysex8_in_1_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.on_sysex8_in_1(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  be_.sysex8_in_1(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData128, SysEx8Start) {
+  midi2::ump::data128::sysex8_start sx;
+  be_.sysex8_start(context_, sx);
+  StrictMock<MockFunction<decltype(be_)::sysex8_start_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.on_sysex8_start(fn.AsStdFunction());
+  be_.sysex8_start(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData128, SysEx8Continue) {
+  midi2::ump::data128::sysex8_continue sx;
+  be_.sysex8_continue(context_, sx);
+  StrictMock<MockFunction<decltype(be_)::sysex8_continue_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.on_sysex8_continue(fn.AsStdFunction());
+  be_.sysex8_continue(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData128, SysEx8End) {
+  midi2::ump::data128::sysex8_end sx;
+  be_.sysex8_end(context_, sx);
+  StrictMock<MockFunction<decltype(be_)::sysex8_end_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, sx)).Times(1);
+  be_.on_sysex8_end(fn.AsStdFunction());
+  be_.sysex8_end(context_, sx);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData128, MDSHeader) {
+  midi2::ump::data128::mds_header mds;
+  be_.mds_header(context_, mds);
+  StrictMock<MockFunction<decltype(be_)::mds_header_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, mds)).Times(1);
+  be_.on_mds_header(fn.AsStdFunction());
+  be_.mds_header(context_, mds);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendData128, MDSPayload) {
+  midi2::ump::data128::mds_payload mds;
+  be_.mds_payload(context_, mds);
+  StrictMock<MockFunction<decltype(be_)::mds_payload_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, mds)).Times(1);
+  be_.on_mds_payload(fn.AsStdFunction());
+  be_.mds_payload(context_, mds);
+}
+
+class DispatcherBackendStream : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::ump_stream_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, EndpointDiscovery) {
+  midi2::ump::ump_stream::endpoint_discovery message;
+  // The first call should do nothing since no handler has been installed.
+  be_.endpoint_discovery(context_, message);
+  // Install a handler for the noop message.
+  StrictMock<MockFunction<decltype(be_)::endpoint_discovery_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_endpoint_discovery(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  be_.endpoint_discovery(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, EndpointNotification) {
+  midi2::ump::ump_stream::endpoint_info_notification message;
+  be_.endpoint_info_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::endpoint_info_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_endpoint_info_notification(fn.AsStdFunction());
+  be_.endpoint_info_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, DeviceIdentityNotification) {
+  midi2::ump::ump_stream::device_identity_notification message;
+  be_.device_identity_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::device_identity_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_device_identity_notification(fn.AsStdFunction());
+  be_.device_identity_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, EndpointNameNotification) {
+  midi2::ump::ump_stream::endpoint_name_notification message;
+  be_.endpoint_name_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::endpoint_name_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_endpoint_name_notification(fn.AsStdFunction());
+  be_.endpoint_name_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, ProduceInstanceIDNotification) {
+  midi2::ump::ump_stream::product_instance_id_notification message;
+  be_.product_instance_id_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::product_instance_id_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_product_instance_id_notification(fn.AsStdFunction());
+  be_.product_instance_id_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, JRConfigurationRequest) {
+  midi2::ump::ump_stream::jr_configuration_request message;
+  be_.jr_configuration_request(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::jr_configuration_request_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_jr_configuration_request(fn.AsStdFunction());
+  be_.jr_configuration_request(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, JRConfigurationNotification) {
+  midi2::ump::ump_stream::jr_configuration_notification message;
+  be_.jr_configuration_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::jr_configuration_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_jr_configuration_notification(fn.AsStdFunction());
+  be_.jr_configuration_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, FunctionBlockDiscovery) {
+  midi2::ump::ump_stream::function_block_discovery message;
+  be_.function_block_discovery(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::function_block_discovery_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_function_block_discovery(fn.AsStdFunction());
+  be_.function_block_discovery(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, FunctionBlockInfoNotification) {
+  midi2::ump::ump_stream::function_block_info_notification message;
+  be_.function_block_info_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::function_block_info_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_function_block_info_notification(fn.AsStdFunction());
+  be_.function_block_info_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, FunctionBlockNameNotification) {
+  midi2::ump::ump_stream::function_block_name_notification message;
+  be_.function_block_name_notification(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::function_block_name_notification_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_function_block_name_notification(fn.AsStdFunction());
+  be_.function_block_name_notification(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, StartOfClip) {
+  midi2::ump::ump_stream::start_of_clip message;
+  be_.start_of_clip(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::start_of_clip_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_start_of_clip(fn.AsStdFunction());
+  be_.start_of_clip(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendStream, EndOfClip) {
+  midi2::ump::ump_stream::end_of_clip message;
+  be_.end_of_clip(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::end_of_clip_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_end_of_clip(fn.AsStdFunction());
+  be_.end_of_clip(context_, message);
+}
+
+class DispatcherBackendFlexData : public testing::Test {
+protected:
+  context_type context_;
+  midi2::dispatcher_backend::flex_data_fn<context_type> be_;
+};
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendFlexData, SetTempo) {
+  midi2::ump::flex_data::set_tempo message;
+  // The first call should do nothing since no handler has been installed.
+  be_.set_tempo(context_, message);
+  // Install a handler for the noop message.
+  StrictMock<MockFunction<decltype(be_)::set_tempo_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_set_tempo(fn.AsStdFunction());
+  // Expect that our handler is called with the correct arguments.
+  be_.set_tempo(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendFlexData, SetTimeSignature) {
+  midi2::ump::flex_data::set_time_signature message;
+  be_.set_time_signature(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::set_time_signature_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_set_time_signature(fn.AsStdFunction());
+  be_.set_time_signature(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendFlexData, SetMetronome) {
+  midi2::ump::flex_data::set_metronome message;
+  be_.set_metronome(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::set_metronome_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_set_metronome(fn.AsStdFunction());
+  be_.set_metronome(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendFlexData, SetKeySignature) {
+  midi2::ump::flex_data::set_key_signature message;
+  be_.set_key_signature(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::set_key_signature_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_set_key_signature(fn.AsStdFunction());
+  be_.set_key_signature(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendFlexData, SetChordName) {
+  midi2::ump::flex_data::set_chord_name message;
+  be_.set_chord_name(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::set_chord_name_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_set_chord_name(fn.AsStdFunction());
+  be_.set_chord_name(context_, message);
+}
+// NOLINTNEXTLINE
+TEST_F(DispatcherBackendFlexData, Text) {
+  midi2::ump::flex_data::text_common message;
+  be_.text(context_, message);
+
+  StrictMock<MockFunction<decltype(be_)::text_fn>> fn;
+  EXPECT_CALL(fn, Call(context_, message)).Times(1);
+  be_.on_text(fn.AsStdFunction());
+  be_.text(context_, message);
+}
+
+}  // end anonymous namespace

--- a/unittests/test_dispatcher_backend.cpp
+++ b/unittests/test_dispatcher_backend.cpp
@@ -7,6 +7,11 @@
 //===------------------------------------------------------------------------------------===//
 #include "midi2/dispatcher_backend.hpp"
 
+// Standard library
+#include <array>
+#include <span>
+
+// Google Test/Mock
 #include <gmock/gmock.h>
 
 namespace {

--- a/unittests/test_dispatcher_backend.cpp
+++ b/unittests/test_dispatcher_backend.cpp
@@ -21,7 +21,7 @@ using testing::InSequence;
 using testing::MockFunction;
 using testing::StrictMock;
 
-constexpr std::uint32_t operator""_u32(unsigned long long v) {
+[[nodiscard]] consteval std::uint32_t operator""_u32(unsigned long long v) {
   assert(v <= std::numeric_limits<std::uint32_t>::max());
   return static_cast<std::uint32_t>(v);
 }
@@ -81,8 +81,8 @@ TEST_F(DispatcherBackendUtility, DeltaClockstamp) {
 // NOLINTNEXTLINE
 TEST_F(DispatcherBackendUtility, Unknown) {
   StrictMock<MockFunction<decltype(be_)::unknown_fn>> fn;
-  std::array message{0xFFFFFFFF_u32, 0xFFFFFFFE_u32, 0xFFFFFFFD_u32, 0xFFFFFFFC_u32, 0xFFFFFFFB_u32};
-  be_.unknown(context_, std::span{message});
+  std::array<std::uint32_t, 5> message{0xFFFFFFFF_u32, 0xFFFFFFFE_u32, 0xFFFFFFFD_u32, 0xFFFFFFFC_u32, 0xFFFFFFFB_u32};
+  be_.unknown(context_, std::span<std::uint32_t>{message});
   be_.on_unknown(fn.AsStdFunction());
   EXPECT_CALL(fn, Call(context_, ElementsAreArray(message))).Times(1);
   be_.unknown(context_, std::span{message});

--- a/unittests/test_ump_dispatcher.cpp
+++ b/unittests/test_ump_dispatcher.cpp
@@ -64,184 +64,73 @@ TEST(UMPApply, ErrorCodeFails) {
 
 using context_type = int;
 
-struct utility_base {
-  utility_base() = default;
-  [[maybe_unused]] utility_base(utility_base const &) = default;
-  [[maybe_unused]] utility_base(utility_base &&) noexcept = default;
-  virtual ~utility_base() noexcept = default;
-
-  [[maybe_unused]] utility_base &operator=(utility_base const &) = default;
-  [[maybe_unused]] utility_base &operator=(utility_base &&) noexcept = default;
-
-  virtual void noop(context_type) = 0;
-  virtual void jr_clock(context_type, midi2::ump::utility::jr_clock) = 0;
-  virtual void jr_timestamp(context_type, midi2::ump::utility::jr_timestamp) = 0;
-  virtual void delta_clockstamp_tpqn(context_type, midi2::ump::utility::delta_clockstamp_tpqn) = 0;
-  virtual void delta_clockstamp(context_type, midi2::ump::utility::delta_clockstamp) = 0;
-
-  virtual void unknown(context_type, std::span<std::uint32_t>) = 0;
-};
-class UtilityMocks : public utility_base {
+class UtilityMocks : public midi2::dispatcher_backend::utility_pure<context_type> {
 public:
   MOCK_METHOD(void, noop, (context_type), (override));
-  MOCK_METHOD(void, jr_clock, (context_type, midi2::ump::utility::jr_clock), (override));
-  MOCK_METHOD(void, jr_timestamp, (context_type, midi2::ump::utility::jr_timestamp), (override));
-  MOCK_METHOD(void, delta_clockstamp_tpqn, (context_type, midi2::ump::utility::delta_clockstamp_tpqn), (override));
-  MOCK_METHOD(void, delta_clockstamp, (context_type, midi2::ump::utility::delta_clockstamp), (override));
+  MOCK_METHOD(void, jr_clock, (context_type, midi2::ump::utility::jr_clock const &), (override));
+  MOCK_METHOD(void, jr_timestamp, (context_type, midi2::ump::utility::jr_timestamp const &), (override));
+  MOCK_METHOD(void, delta_clockstamp_tpqn, (context_type, midi2::ump::utility::delta_clockstamp_tpqn const &),
+              (override));
+  MOCK_METHOD(void, delta_clockstamp, (context_type, midi2::ump::utility::delta_clockstamp const &), (override));
 
   MOCK_METHOD(void, unknown, (context_type, std::span<std::uint32_t>), (override));
 };
-struct system_base {
-  system_base() = default;
-  [[maybe_unused]] system_base(system_base const &) = default;
-  [[maybe_unused]] system_base(system_base &&) noexcept = default;
-  virtual ~system_base() noexcept = default;
-
-  [[maybe_unused]] system_base &operator=(system_base const &) = default;
-  [[maybe_unused]] system_base &operator=(system_base &&) noexcept = default;
-
-  virtual void midi_time_code(context_type, midi2::ump::system::midi_time_code) = 0;
-  virtual void song_position_pointer(context_type, midi2::ump::system::song_position_pointer) = 0;
-  virtual void song_select(context_type, midi2::ump::system::song_select) = 0;
-  virtual void tune_request(context_type, midi2::ump::system::tune_request) = 0;
-  virtual void timing_clock(context_type, midi2::ump::system::timing_clock) = 0;
-  virtual void seq_start(context_type, midi2::ump::system::sequence_start) = 0;
-  virtual void seq_continue(context_type, midi2::ump::system::sequence_continue) = 0;
-  virtual void seq_stop(context_type, midi2::ump::system::sequence_stop) = 0;
-  virtual void active_sensing(context_type, midi2::ump::system::active_sensing) = 0;
-  virtual void reset(context_type, midi2::ump::system::reset) = 0;
-};
-class SystemMocks : public system_base {
+class SystemMocks : public midi2::dispatcher_backend::system_pure<context_type> {
 public:
-  MOCK_METHOD(void, midi_time_code, (context_type, midi2::ump::system::midi_time_code), (override));
-  MOCK_METHOD(void, song_position_pointer, (context_type, midi2::ump::system::song_position_pointer), (override));
-  MOCK_METHOD(void, song_select, (context_type, midi2::ump::system::song_select), (override));
-  MOCK_METHOD(void, tune_request, (context_type, midi2::ump::system::tune_request), (override));
-  MOCK_METHOD(void, timing_clock, (context_type, midi2::ump::system::timing_clock), (override));
-  MOCK_METHOD(void, seq_start, (context_type, midi2::ump::system::sequence_start), (override));
-  MOCK_METHOD(void, seq_continue, (context_type, midi2::ump::system::sequence_continue), (override));
-  MOCK_METHOD(void, seq_stop, (context_type, midi2::ump::system::sequence_stop), (override));
-  MOCK_METHOD(void, active_sensing, (context_type, midi2::ump::system::active_sensing), (override));
-  MOCK_METHOD(void, reset, (context_type, midi2::ump::system::reset), (override));
+  MOCK_METHOD(void, midi_time_code, (context_type, midi2::ump::system::midi_time_code const &), (override));
+  MOCK_METHOD(void, song_position_pointer, (context_type, midi2::ump::system::song_position_pointer const &),
+              (override));
+  MOCK_METHOD(void, song_select, (context_type, midi2::ump::system::song_select const &), (override));
+  MOCK_METHOD(void, tune_request, (context_type, midi2::ump::system::tune_request const &), (override));
+  MOCK_METHOD(void, timing_clock, (context_type, midi2::ump::system::timing_clock const &), (override));
+  MOCK_METHOD(void, seq_start, (context_type, midi2::ump::system::sequence_start const &), (override));
+  MOCK_METHOD(void, seq_continue, (context_type, midi2::ump::system::sequence_continue const &), (override));
+  MOCK_METHOD(void, seq_stop, (context_type, midi2::ump::system::sequence_stop const &), (override));
+  MOCK_METHOD(void, active_sensing, (context_type, midi2::ump::system::active_sensing const &), (override));
+  MOCK_METHOD(void, reset, (context_type, midi2::ump::system::reset const &), (override));
 };
-struct m1cvm_base {
-  m1cvm_base() = default;
-  [[maybe_unused]] m1cvm_base(m1cvm_base const &) = default;
-  [[maybe_unused]] m1cvm_base(m1cvm_base &&) noexcept = default;
-  virtual ~m1cvm_base() noexcept = default;
-
-  [[maybe_unused]] m1cvm_base &operator=(m1cvm_base const &) = default;
-  [[maybe_unused]] m1cvm_base &operator=(m1cvm_base &&) noexcept = default;
-
-  virtual void note_off(context_type, midi2::ump::m1cvm::note_off) = 0;
-  virtual void note_on(context_type, midi2::ump::m1cvm::note_on) = 0;
-  virtual void poly_pressure(context_type, midi2::ump::m1cvm::poly_pressure) = 0;
-  virtual void control_change(context_type, midi2::ump::m1cvm::control_change) = 0;
-  virtual void program_change(context_type, midi2::ump::m1cvm::program_change) = 0;
-  virtual void channel_pressure(context_type, midi2::ump::m1cvm::channel_pressure) = 0;
-  virtual void pitch_bend(context_type, midi2::ump::m1cvm::pitch_bend) = 0;
-};
-class M1CVMMocks : public m1cvm_base {
+class M1CVMMocks : public midi2::dispatcher_backend::m1cvm_pure<context_type> {
 public:
-  MOCK_METHOD(void, note_off, (context_type, midi2::ump::m1cvm::note_off), (override));
-  MOCK_METHOD(void, note_on, (context_type, midi2::ump::m1cvm::note_on), (override));
-  MOCK_METHOD(void, poly_pressure, (context_type, midi2::ump::m1cvm::poly_pressure), (override));
-  MOCK_METHOD(void, control_change, (context_type, midi2::ump::m1cvm::control_change), (override));
-  MOCK_METHOD(void, program_change, (context_type, midi2::ump::m1cvm::program_change), (override));
-  MOCK_METHOD(void, channel_pressure, (context_type, midi2::ump::m1cvm::channel_pressure), (override));
-  MOCK_METHOD(void, pitch_bend, (context_type, midi2::ump::m1cvm::pitch_bend), (override));
+  MOCK_METHOD(void, note_off, (context_type, midi2::ump::m1cvm::note_off const &), (override));
+  MOCK_METHOD(void, note_on, (context_type, midi2::ump::m1cvm::note_on const &), (override));
+  MOCK_METHOD(void, poly_pressure, (context_type, midi2::ump::m1cvm::poly_pressure const &), (override));
+  MOCK_METHOD(void, control_change, (context_type, midi2::ump::m1cvm::control_change const &), (override));
+  MOCK_METHOD(void, program_change, (context_type, midi2::ump::m1cvm::program_change const &), (override));
+  MOCK_METHOD(void, channel_pressure, (context_type, midi2::ump::m1cvm::channel_pressure const &), (override));
+  MOCK_METHOD(void, pitch_bend, (context_type, midi2::ump::m1cvm::pitch_bend const &), (override));
 };
-struct data64_base {
-  data64_base() = default;
-  [[maybe_unused]] data64_base(data64_base const &) = default;
-  [[maybe_unused]] data64_base(data64_base &&) noexcept = default;
-  virtual ~data64_base() noexcept = default;
-
-  [[maybe_unused]] data64_base &operator=(data64_base const &) = default;
-  [[maybe_unused]] data64_base &operator=(data64_base &&) noexcept = default;
-
-  virtual void sysex7_in_1(context_type, midi2::ump::data64::sysex7_in_1) = 0;
-  virtual void sysex7_start(context_type, midi2::ump::data64::sysex7_start) = 0;
-  virtual void sysex7_continue(context_type, midi2::ump::data64::sysex7_continue) = 0;
-  virtual void sysex7_end(context_type, midi2::ump::data64::sysex7_end) = 0;
-};
-class Data64Mocks : public data64_base {
+class Data64Mocks : public midi2::dispatcher_backend::data64_pure<context_type> {
 public:
-  MOCK_METHOD(void, sysex7_in_1, (context_type, midi2::ump::data64::sysex7_in_1), (override));
-  MOCK_METHOD(void, sysex7_start, (context_type, midi2::ump::data64::sysex7_start), (override));
-  MOCK_METHOD(void, sysex7_continue, (context_type, midi2::ump::data64::sysex7_continue), (override));
-  MOCK_METHOD(void, sysex7_end, (context_type, midi2::ump::data64::sysex7_end), (override));
+  MOCK_METHOD(void, sysex7_in_1, (context_type, midi2::ump::data64::sysex7_in_1 const &), (override));
+  MOCK_METHOD(void, sysex7_start, (context_type, midi2::ump::data64::sysex7_start const &), (override));
+  MOCK_METHOD(void, sysex7_continue, (context_type, midi2::ump::data64::sysex7_continue const &), (override));
+  MOCK_METHOD(void, sysex7_end, (context_type, midi2::ump::data64::sysex7_end const &), (override));
 };
-struct m2cvm_base {
-  m2cvm_base() = default;
-  [[maybe_unused]] m2cvm_base(m2cvm_base const &) = default;
-  [[maybe_unused]] m2cvm_base(m2cvm_base &&) noexcept = default;
-  virtual ~m2cvm_base() noexcept = default;
-
-  [[maybe_unused]] m2cvm_base &operator=(m2cvm_base const &) = default;
-  [[maybe_unused]] m2cvm_base &operator=(m2cvm_base &&) noexcept = default;
-
-  virtual void note_off(context_type, midi2::ump::m2cvm::note_off) = 0;
-  virtual void note_on(context_type, midi2::ump::m2cvm::note_on) = 0;
-  virtual void poly_pressure(context_type, midi2::ump::m2cvm::poly_pressure) = 0;
-  virtual void program_change(context_type, midi2::ump::m2cvm::program_change) = 0;
-  virtual void channel_pressure(context_type, midi2::ump::m2cvm::channel_pressure) = 0;
-
-  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x0)
-  virtual void rpn_per_note_controller(context_type, midi2::ump::m2cvm::rpn_per_note_controller) = 0;
-  // 7.4.4 MIDI 2.0 Registered Per-Note Controller Message (status=0x1)
-  virtual void nrpn_per_note_controller(context_type, midi2::ump::m2cvm::nrpn_per_note_controller) = 0;
-  // 7.4.7 MIDI 2.0 Registered Controller (RPN) Message (status=0x2)
-  virtual void rpn_controller(context_type, midi2::ump::m2cvm::rpn_controller) = 0;
-  // 7.4.7 MIDI 2.0 Assignable Controller (NRPN) Message (status=0x3)
-  virtual void nrpn_controller(context_type, midi2::ump::m2cvm::nrpn_controller) = 0;
-  // 7.4.8 MIDI 2.0 Relative Registered Controller (RPN) Message (status=0x4)
-  virtual void rpn_relative_controller(context_type, midi2::ump::m2cvm::rpn_relative_controller) = 0;
-  // 7.4.8 MIDI 2.0 Relative Assignable Controller (NRPN) Message (status=0x5)
-  virtual void nrpn_relative_controller(context_type, midi2::ump::m2cvm::nrpn_relative_controller) = 0;
-
-  virtual void per_note_management(context_type, midi2::ump::m2cvm::per_note_management) = 0;
-  virtual void control_change(context_type, midi2::ump::m2cvm::control_change) = 0;
-  virtual void pitch_bend(context_type, midi2::ump::m2cvm::pitch_bend) = 0;
-  virtual void per_note_pitch_bend(context_type, midi2::ump::m2cvm::per_note_pitch_bend) = 0;
-};
-class M2CVMMocks : public m2cvm_base {
+class M2CVMMocks : public midi2::dispatcher_backend::m2cvm_pure<context_type> {
 public:
-  MOCK_METHOD(void, note_off, (context_type, midi2::ump::m2cvm::note_off), (override));
-  MOCK_METHOD(void, note_on, (context_type, midi2::ump::m2cvm::note_on), (override));
-  MOCK_METHOD(void, poly_pressure, (context_type, midi2::ump::m2cvm::poly_pressure), (override));
-  MOCK_METHOD(void, program_change, (context_type, midi2::ump::m2cvm::program_change), (override));
-  MOCK_METHOD(void, channel_pressure, (context_type, midi2::ump::m2cvm::channel_pressure), (override));
+  MOCK_METHOD(void, note_off, (context_type, midi2::ump::m2cvm::note_off const &), (override));
+  MOCK_METHOD(void, note_on, (context_type, midi2::ump::m2cvm::note_on const &), (override));
+  MOCK_METHOD(void, poly_pressure, (context_type, midi2::ump::m2cvm::poly_pressure const &), (override));
+  MOCK_METHOD(void, program_change, (context_type, midi2::ump::m2cvm::program_change const &), (override));
+  MOCK_METHOD(void, channel_pressure, (context_type, midi2::ump::m2cvm::channel_pressure const &), (override));
 
-  MOCK_METHOD(void, rpn_per_note_controller, (context_type, midi2::ump::m2cvm::rpn_per_note_controller), (override));
-  MOCK_METHOD(void, nrpn_per_note_controller, (context_type, midi2::ump::m2cvm::nrpn_per_note_controller), (override));
-  MOCK_METHOD(void, rpn_controller, (context_type, midi2::ump::m2cvm::rpn_controller), (override));
-  MOCK_METHOD(void, nrpn_controller, (context_type, midi2::ump::m2cvm::nrpn_controller), (override));
-  MOCK_METHOD(void, rpn_relative_controller, (context_type, midi2::ump::m2cvm::rpn_relative_controller), (override));
-  MOCK_METHOD(void, nrpn_relative_controller, (context_type, midi2::ump::m2cvm::nrpn_relative_controller), (override));
+  MOCK_METHOD(void, rpn_per_note_controller, (context_type, midi2::ump::m2cvm::rpn_per_note_controller const &),
+              (override));
+  MOCK_METHOD(void, nrpn_per_note_controller, (context_type, midi2::ump::m2cvm::nrpn_per_note_controller const &),
+              (override));
+  MOCK_METHOD(void, rpn_controller, (context_type, midi2::ump::m2cvm::rpn_controller const &), (override));
+  MOCK_METHOD(void, nrpn_controller, (context_type, midi2::ump::m2cvm::nrpn_controller const &), (override));
+  MOCK_METHOD(void, rpn_relative_controller, (context_type, midi2::ump::m2cvm::rpn_relative_controller const &),
+              (override));
+  MOCK_METHOD(void, nrpn_relative_controller, (context_type, midi2::ump::m2cvm::nrpn_relative_controller const &),
+              (override));
 
-  MOCK_METHOD(void, per_note_management, (context_type, midi2::ump::m2cvm::per_note_management), (override));
-  MOCK_METHOD(void, control_change, (context_type, midi2::ump::m2cvm::control_change), (override));
-  MOCK_METHOD(void, pitch_bend, (context_type, midi2::ump::m2cvm::pitch_bend), (override));
-  MOCK_METHOD(void, per_note_pitch_bend, (context_type, midi2::ump::m2cvm::per_note_pitch_bend), (override));
+  MOCK_METHOD(void, per_note_management, (context_type, midi2::ump::m2cvm::per_note_management const &), (override));
+  MOCK_METHOD(void, control_change, (context_type, midi2::ump::m2cvm::control_change const &), (override));
+  MOCK_METHOD(void, pitch_bend, (context_type, midi2::ump::m2cvm::pitch_bend const &), (override));
+  MOCK_METHOD(void, per_note_pitch_bend, (context_type, midi2::ump::m2cvm::per_note_pitch_bend const &), (override));
 };
-struct data128_base {
-  data128_base() = default;
-  [[maybe_unused]] data128_base(data128_base const &) = default;
-  [[maybe_unused]] data128_base(data128_base &&) noexcept = default;
-  virtual ~data128_base() noexcept = default;
-
-  [[maybe_unused]] data128_base &operator=(data128_base const &) = default;
-  [[maybe_unused]] data128_base &operator=(data128_base &&) noexcept = default;
-
-  virtual void sysex8_in_1(context_type, midi2::ump::data128::sysex8_in_1 const &) = 0;
-  virtual void sysex8_start(context_type, midi2::ump::data128::sysex8_start const &) = 0;
-  virtual void sysex8_continue(context_type, midi2::ump::data128::sysex8_continue const &) = 0;
-  virtual void sysex8_end(context_type, midi2::ump::data128::sysex8_end const &) = 0;
-  virtual void mds_header(context_type, midi2::ump::data128::mds_header const &) = 0;
-  virtual void mds_payload(context_type, midi2::ump::data128::mds_payload const &) = 0;
-};
-class Data128Mocks : public data128_base {
+class Data128Mocks : public midi2::dispatcher_backend::data128_pure<context_type> {
 public:
   MOCK_METHOD(void, sysex8_in_1, (context_type, midi2::ump::data128::sysex8_in_1 const &), (override));
   MOCK_METHOD(void, sysex8_start, (context_type, midi2::ump::data128::sysex8_start const &), (override));
@@ -250,84 +139,41 @@ public:
   MOCK_METHOD(void, mds_header, (context_type, midi2::ump::data128::mds_header const &), (override));
   MOCK_METHOD(void, mds_payload, (context_type, midi2::ump::data128::mds_payload const &), (override));
 };
-struct ump_stream_base {
-  ump_stream_base() = default;
-  [[maybe_unused]] ump_stream_base(ump_stream_base const &) = default;
-  [[maybe_unused]] ump_stream_base(ump_stream_base &&) noexcept = default;
-  virtual ~ump_stream_base() noexcept = default;
-
-  [[maybe_unused]] ump_stream_base &operator=(ump_stream_base const &) = default;
-  [[maybe_unused]] ump_stream_base &operator=(ump_stream_base &&) noexcept = default;
-
-  virtual void endpoint_discovery(context_type, midi2::ump::ump_stream::endpoint_discovery) = 0;
-  virtual void endpoint_info_notification(context_type, midi2::ump::ump_stream::endpoint_info_notification) = 0;
-  virtual void device_identity_notification(context_type, midi2::ump::ump_stream::device_identity_notification) = 0;
-  virtual void endpoint_name_notification(context_type, midi2::ump::ump_stream::endpoint_name_notification) = 0;
-  virtual void product_instance_id_notification(context_type,
-                                                midi2::ump::ump_stream::product_instance_id_notification) = 0;
-  virtual void jr_configuration_request(context_type, midi2::ump::ump_stream::jr_configuration_request) = 0;
-  virtual void jr_configuration_notification(context_type, midi2::ump::ump_stream::jr_configuration_notification) = 0;
-
-  virtual void function_block_discovery(context_type, midi2::ump::ump_stream::function_block_discovery) = 0;
-  virtual void function_block_info_notification(context_type,
-                                                midi2::ump::ump_stream::function_block_info_notification) = 0;
-  virtual void function_block_name_notification(context_type,
-                                                midi2::ump::ump_stream::function_block_name_notification) = 0;
-
-  virtual void start_of_clip(context_type, midi2::ump::ump_stream::start_of_clip) = 0;
-  virtual void end_of_clip(context_type, midi2::ump::ump_stream::end_of_clip) = 0;
-};
-class UMPStreamMocks : public ump_stream_base {
+class UMPStreamMocks : public midi2::dispatcher_backend::ump_stream_base<context_type> {
 public:
-  MOCK_METHOD(void, endpoint_discovery, (context_type, midi2::ump::ump_stream::endpoint_discovery), (override));
-  MOCK_METHOD(void, endpoint_info_notification, (context_type, midi2::ump::ump_stream::endpoint_info_notification),
-              (override));
-  MOCK_METHOD(void, device_identity_notification, (context_type, midi2::ump::ump_stream::device_identity_notification),
-              (override));
-  MOCK_METHOD(void, endpoint_name_notification, (context_type, midi2::ump::ump_stream::endpoint_name_notification),
-              (override));
+  MOCK_METHOD(void, endpoint_discovery, (context_type, midi2::ump::ump_stream::endpoint_discovery const &), (override));
+  MOCK_METHOD(void, endpoint_info_notification,
+              (context_type, midi2::ump::ump_stream::endpoint_info_notification const &), (override));
+  MOCK_METHOD(void, device_identity_notification,
+              (context_type, midi2::ump::ump_stream::device_identity_notification const &), (override));
+  MOCK_METHOD(void, endpoint_name_notification,
+              (context_type, midi2::ump::ump_stream::endpoint_name_notification const &), (override));
   MOCK_METHOD(void, product_instance_id_notification,
-              (context_type, midi2::ump::ump_stream::product_instance_id_notification), (override));
+              (context_type, midi2::ump::ump_stream::product_instance_id_notification const &), (override));
 
-  MOCK_METHOD(void, jr_configuration_request, (context_type, midi2::ump::ump_stream::jr_configuration_request),
+  MOCK_METHOD(void, jr_configuration_request, (context_type, midi2::ump::ump_stream::jr_configuration_request const &),
               (override));
   MOCK_METHOD(void, jr_configuration_notification,
-              (context_type, midi2::ump::ump_stream::jr_configuration_notification), (override));
+              (context_type, midi2::ump::ump_stream::jr_configuration_notification const &), (override));
 
-  MOCK_METHOD(void, function_block_discovery, (context_type, midi2::ump::ump_stream::function_block_discovery),
+  MOCK_METHOD(void, function_block_discovery, (context_type, midi2::ump::ump_stream::function_block_discovery const &),
               (override));
   MOCK_METHOD(void, function_block_info_notification,
-              (context_type, midi2::ump::ump_stream::function_block_info_notification), (override));
+              (context_type, midi2::ump::ump_stream::function_block_info_notification const &), (override));
   MOCK_METHOD(void, function_block_name_notification,
-              (context_type, midi2::ump::ump_stream::function_block_name_notification), (override));
+              (context_type, midi2::ump::ump_stream::function_block_name_notification const &), (override));
 
-  MOCK_METHOD(void, start_of_clip, (context_type, midi2::ump::ump_stream::start_of_clip), (override));
-  MOCK_METHOD(void, end_of_clip, (context_type, midi2::ump::ump_stream::end_of_clip), (override));
+  MOCK_METHOD(void, start_of_clip, (context_type, midi2::ump::ump_stream::start_of_clip const &), (override));
+  MOCK_METHOD(void, end_of_clip, (context_type, midi2::ump::ump_stream::end_of_clip const &), (override));
 };
-struct flex_data_base {
-  flex_data_base() = default;
-  [[maybe_unused]] flex_data_base(flex_data_base const &) = default;
-  [[maybe_unused]] flex_data_base(flex_data_base &&) noexcept = default;
-  virtual ~flex_data_base() noexcept = default;
-
-  [[maybe_unused]] flex_data_base &operator=(flex_data_base const &) = default;
-  [[maybe_unused]] flex_data_base &operator=(flex_data_base &&) noexcept = default;
-
-  virtual void set_tempo(context_type, midi2::ump::flex_data::set_tempo) = 0;
-  virtual void set_time_signature(context_type, midi2::ump::flex_data::set_time_signature) = 0;
-  virtual void set_metronome(context_type, midi2::ump::flex_data::set_metronome) = 0;
-  virtual void set_key_signature(context_type, midi2::ump::flex_data::set_key_signature) = 0;
-  virtual void set_chord_name(context_type, midi2::ump::flex_data::set_chord_name) = 0;
-  virtual void text(context_type, midi2::ump::flex_data::text_common) = 0;
-};
-class FlexDataMocks : public flex_data_base {
+class FlexDataMocks : public midi2::dispatcher_backend::flex_data_pure<context_type> {
 public:
-  MOCK_METHOD(void, set_tempo, (context_type, midi2::ump::flex_data::set_tempo), (override));
-  MOCK_METHOD(void, set_time_signature, (context_type, midi2::ump::flex_data::set_time_signature), (override));
-  MOCK_METHOD(void, set_metronome, (context_type, midi2::ump::flex_data::set_metronome), (override));
-  MOCK_METHOD(void, set_key_signature, (context_type, midi2::ump::flex_data::set_key_signature), (override));
-  MOCK_METHOD(void, set_chord_name, (context_type, midi2::ump::flex_data::set_chord_name), (override));
-  MOCK_METHOD(void, text, (context_type, midi2::ump::flex_data::text_common), (override));
+  MOCK_METHOD(void, set_tempo, (context_type, midi2::ump::flex_data::set_tempo const &), (override));
+  MOCK_METHOD(void, set_time_signature, (context_type, midi2::ump::flex_data::set_time_signature const &), (override));
+  MOCK_METHOD(void, set_metronome, (context_type, midi2::ump::flex_data::set_metronome const &), (override));
+  MOCK_METHOD(void, set_key_signature, (context_type, midi2::ump::flex_data::set_key_signature const &), (override));
+  MOCK_METHOD(void, set_chord_name, (context_type, midi2::ump::flex_data::set_chord_name const &), (override));
+  MOCK_METHOD(void, text, (context_type, midi2::ump::flex_data::text_common const &), (override));
 };
 
 }  // end anonymous namespace


### PR DESCRIPTION
This defines three backends for the UMP-dispatcher: "pure" uses pure virtual methods, "base" provides virtual methods with default noop implementations, "null" provides non-virtual methods with noop implementations, and "fn" provides implementations using std::function<>.