### PR TITLE
Update codecov action to 7.0

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -81,7 +81,7 @@ jobs:
           path: coverage.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This is to resolve failures that I'm seeing in CI: "Could not verify signature. Please contact Codecov if problem continues". According to https://github.com/codecov/codecov-action/issues/1956, this should be fixed in the newer version.